### PR TITLE
use rawName when check selfClosing Tag

### DIFF
--- a/src/html/parser.ts
+++ b/src/html/parser.ts
@@ -491,7 +491,7 @@ export class Parser {
 
         // Check whether the self-closing is valid.
         const isVoid =
-            namespace === NS.HTML && HTML_VOID_ELEMENT_TAGS.has(element.name)
+            namespace === NS.HTML && HTML_VOID_ELEMENT_TAGS.has(element.rawName)
         if (token.selfClosing && !isVoid && namespace === NS.HTML) {
             this.reportParseError(
                 token,


### PR DESCRIPTION
in View UI (https://www.iviewui.com/), Col can close, but check will fail.