### PR TITLE
Add defineCustomBlocksVisitor to parserServices

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ But, it cannot be parsed with Vue 2.
     - `defineTemplateBodyVisitor(templateVisitor, scriptVisitor)` ... returns ESLint visitor to traverse `<template>`.
     - `getTemplateBodyTokenStore()` ... returns ESLint `TokenStore` to get the tokens of `<template>`.
     - `getDocumentFragment()` ... returns the root `VDocumentFragment`.
+    - `defineCustomBlocksVisitor(context, customParser, rule, scriptVisitor)` ... returns ESLint visitor that parses and traverses the contents of the custom block.
 - [ast.md](./docs/ast.md) is `<template>` AST specification.
 - [mustache-interpolation-spacing.js](https://github.com/vuejs/eslint-plugin-vue/blob/b434ff99d37f35570fa351681e43ba2cf5746db3/lib/rules/mustache-interpolation-spacing.js) is an example.
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "devDependencies": {
     "@mysticatea/eslint-plugin": "^13.0.0",
     "@types/debug": "0.0.30",
-    "@types/estree": "0.0.38",
+    "@types/eslint": "^7.2.6",
+    "@types/estree": "0.0.45",
     "@types/lodash": "^4.14.120",
     "@types/mocha": "^5.2.4",
     "@types/node": "^10.12.21",
@@ -35,6 +36,7 @@
     "dts-bundle": "^0.7.3",
     "eslint": "^7.0.0",
     "fs-extra": "^7.0.1",
+    "jsonc-eslint-parser": "^0.6.0",
     "mocha": "^6.1.4",
     "npm-run-all": "^4.1.5",
     "nyc": "^14.0.0",

--- a/src/common/fix-locations.ts
+++ b/src/common/fix-locations.ts
@@ -1,0 +1,67 @@
+import {
+    ESLintExtendedProgram,
+    LocationRange,
+    Node,
+    traverseNodes,
+} from "../ast"
+import { LocationCalculator } from "./location-calculator"
+
+/**
+ * Do post-process of parsing an expression.
+ *
+ * 1. Set `node.parent`.
+ * 2. Fix `node.range` and `node.loc` for HTML entities.
+ *
+ * @param result The parsing result to modify.
+ * @param locationCalculator The location calculator to modify.
+ */
+export function fixLocations(
+    result: ESLintExtendedProgram,
+    locationCalculator: LocationCalculator,
+): void {
+    // There are cases which the same node instance appears twice in the tree.
+    // E.g. `let {a} = {}` // This `a` appears twice at `Property#key` and `Property#value`.
+    const traversed = new Set<Node | number[] | LocationRange>()
+
+    traverseNodes(result.ast, {
+        visitorKeys: result.visitorKeys,
+
+        enterNode(node, parent) {
+            if (!traversed.has(node)) {
+                traversed.add(node)
+                node.parent = parent
+
+                // `babel-eslint@8` has shared `Node#range` with multiple nodes.
+                // See also: https://github.com/vuejs/eslint-plugin-vue/issues/208
+                if (traversed.has(node.range)) {
+                    if (!traversed.has(node.loc)) {
+                        // However, `Node#loc` may not be shared.
+                        // See also: https://github.com/vuejs/vue-eslint-parser/issues/84
+                        node.loc.start = locationCalculator.getLocFromIndex(
+                            node.range[0],
+                        )
+                        node.loc.end = locationCalculator.getLocFromIndex(
+                            node.range[1],
+                        )
+                        traversed.add(node.loc)
+                    }
+                } else {
+                    locationCalculator.fixLocation(node)
+                    traversed.add(node.range)
+                    traversed.add(node.loc)
+                }
+            }
+        },
+
+        leaveNode() {
+            // Do nothing.
+        },
+    })
+
+    for (const token of result.ast.tokens || []) {
+        locationCalculator.fixLocation(token)
+    }
+    for (const comment of result.ast.comments || []) {
+        locationCalculator.fixLocation(comment)
+    }
+}

--- a/src/common/parser-options.ts
+++ b/src/common/parser-options.ts
@@ -1,3 +1,5 @@
+import * as path from "path"
+
 export interface ParserOptions {
     // vue-eslint-parser options
     parser?: boolean | string
@@ -32,4 +34,11 @@ export interface ParserOptions {
 
     // others
     // [key: string]: any
+}
+
+export function isSFCFile(parserOptions: ParserOptions) {
+    if (parserOptions.filePath === "<input>") {
+        return true
+    }
+    return path.extname(parserOptions.filePath || "unknown.vue") === ".vue"
 }

--- a/src/html/parser.ts
+++ b/src/html/parser.ts
@@ -3,7 +3,6 @@
  * @copyright 2017 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
-import * as path from "path"
 import assert from "assert"
 import last from "lodash/last"
 import findLastIndex from "lodash/findLastIndex"
@@ -47,7 +46,7 @@ import {
     Text,
 } from "./intermediate-tokenizer"
 import { Tokenizer } from "./tokenizer"
-import { ParserOptions } from "../common/parser-options"
+import { isSFCFile, ParserOptions } from "../common/parser-options"
 
 const DIRECTIVE_NAME = /^(?:v-|[.:@#]).*[^.:@#]$/u
 const DT_DD = /^d[dt]$/u
@@ -232,8 +231,7 @@ export class Parser {
             tokenizer.lineTerminators,
         )
         this.parserOptions = parserOptions
-        this.isSFC =
-            path.extname(parserOptions.filePath || "unknown.vue") === ".vue"
+        this.isSFC = isSFCFile(parserOptions)
         this.document = {
             type: "VDocumentFragment",
             range: [0, 0],

--- a/src/parser-services.ts
+++ b/src/parser-services.ts
@@ -3,6 +3,7 @@
  * @copyright 2017 Toru Nagashima. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
+import { Rule } from "eslint"
 import EventEmitter from "events"
 import NodeEventGenerator from "./external/node-event-generator"
 import TokenStore from "./external/token-store"
@@ -11,11 +12,30 @@ import {
     ESLintProgram,
     VElement,
     VDocumentFragment,
+    VAttribute,
 } from "./ast"
+import { LocationCalculator } from "./common/location-calculator"
+import {
+    createCustomBlockSharedContext,
+    CustomBlockContext,
+    ESLintCustomBlockParser,
+    getCustomBlocks,
+    getLang,
+    parseCustomBlockElement,
+} from "./sfc/custom-block"
 
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
+
+type CustomBlockVisitorFactory = (
+    context: CustomBlockContext,
+) =>
+    | {
+          [key: string]: (...args: any) => void
+      }
+    | null
+    | undefined
 
 const emitters = new WeakMap<object, EventEmitter>()
 const stores = new WeakMap<object, TokenStore>()
@@ -36,6 +56,26 @@ export interface ParserServices {
     ): object
 
     /**
+     * Define handlers to traverse custom blocks.
+     * @param context The rule context.
+     * @param parser The custom parser.
+     * @param rule The custom block rule definition
+     * @param scriptVisitor The script handlers. This is optional.
+     */
+    defineCustomBlocksVisitor(
+        context: Rule.RuleContext,
+        parser: ESLintCustomBlockParser,
+        rule: {
+            target:
+                | string
+                | string[]
+                | ((lang: string | null, customBlock: VElement) => boolean)
+            create: CustomBlockVisitorFactory
+        },
+        scriptVisitor: { [key: string]: (...args: any) => void },
+    ): { [key: string]: (...args: any) => void }
+
+    /**
      * Get the token store of the template body.
      * @returns The token store of template body.
      */
@@ -53,9 +93,21 @@ export interface ParserServices {
  * @param rootAST
  */
 export function define(
+    sourceText: string,
     rootAST: ESLintProgram,
     document: VDocumentFragment | null,
+    globalLocationCalculator: LocationCalculator | null,
+    { parserOptions }: { parserOptions: object },
 ): ParserServices {
+    const customBlocksEmitters = new Map<
+        ESLintCustomBlockParser,
+        {
+            context: Rule.RuleContext
+            test: (lang: string | null, customBlock: VElement) => boolean
+            create: CustomBlockVisitorFactory
+        }[]
+    >()
+
     return {
         /**
          * Define handlers to traverse the template body.
@@ -109,6 +161,137 @@ export function define(
             for (const selector of Object.keys(templateBodyVisitor)) {
                 emitter.on(selector, templateBodyVisitor[selector])
             }
+
+            return scriptVisitor
+        },
+
+        /**
+         * Define handlers to traverse custom blocks.
+         * @param context The rule context.
+         * @param parser The custom parser.
+         * @param rule The custom block rule definition
+         * @param scriptVisitor The script handlers. This is optional.
+         */
+        defineCustomBlocksVisitor(
+            context: Rule.RuleContext,
+            parser: ESLintCustomBlockParser,
+            rule: {
+                target:
+                    | string
+                    | string[]
+                    | ((lang: string | null, customBlock: VElement) => boolean)
+                create: CustomBlockVisitorFactory
+            },
+            scriptVisitor: { [key: string]: (...args: any) => void },
+        ): { [key: string]: (...args: any) => void } {
+            if (scriptVisitor == null) {
+                scriptVisitor = {} //eslint-disable-line no-param-reassign
+            }
+            parserOptions = { ...parserOptions } //eslint-disable-line no-param-reassign
+            const customBlocks = getCustomBlocks(document).filter(
+                block =>
+                    block.endTag &&
+                    !block.startTag.attributes.some(
+                        (attr): attr is VAttribute =>
+                            !attr.directive && attr.key.name === "src",
+                    ),
+            )
+            if (!customBlocks.length || globalLocationCalculator == null) {
+                return {}
+            }
+            let factories = customBlocksEmitters.get(parser)
+
+            // If this is the first time, initialize the intermediate event emitter.
+            if (factories == null) {
+                factories = []
+                customBlocksEmitters.set(parser, factories)
+                const visitorFactories = factories
+
+                const programExitHandler = scriptVisitor["Program:exit"]
+                scriptVisitor["Program:exit"] = node => {
+                    try {
+                        if (typeof programExitHandler === "function") {
+                            programExitHandler(node)
+                        }
+                        for (const customBlock of customBlocks) {
+                            const lang = getLang(customBlock)
+
+                            const activeVisitorFactories = visitorFactories.filter(
+                                f => f.test(lang, customBlock),
+                            )
+                            if (!activeVisitorFactories.length) {
+                                continue
+                            }
+
+                            const parsedResult = parseCustomBlockElement(
+                                customBlock,
+                                parser,
+                                globalLocationCalculator,
+                                parserOptions,
+                            )
+
+                            const {
+                                serCurrentNode,
+                                context: customBlockContext,
+                            } = createCustomBlockSharedContext({
+                                text: sourceText,
+                                customBlock,
+                                parsedResult,
+                                parserOptions,
+                            })
+
+                            const emitter = new EventEmitter()
+                            emitter.setMaxListeners(0)
+
+                            for (const factory of activeVisitorFactories) {
+                                const visitor = factory.create({
+                                    ...factory.context,
+                                    ...customBlockContext,
+                                })
+                                // Register handlers into the intermediate event emitter.
+                                for (const selector of Object.keys(
+                                    visitor || {},
+                                )) {
+                                    emitter.on(selector, visitor![selector])
+                                }
+                            }
+
+                            // Traverse custom block.
+                            const generator = new NodeEventGenerator(emitter)
+                            traverseNodes(parsedResult.ast, {
+                                visitorKeys: parsedResult.visitorKeys,
+                                enterNode(n) {
+                                    serCurrentNode(n)
+                                    generator.enterNode(n)
+                                },
+                                leaveNode(n) {
+                                    serCurrentNode(n)
+                                    generator.leaveNode(n)
+                                },
+                            })
+                        }
+                    } finally {
+                        // eslint-disable-next-line @mysticatea/ts/ban-ts-ignore
+                        // @ts-ignore
+                        scriptVisitor["Program:exit"] = programExitHandler
+                        customBlocksEmitters.delete(parser)
+                    }
+                }
+            }
+
+            const target = rule.target
+            const test =
+                typeof target === "function"
+                    ? target
+                    : Array.isArray(target)
+                    ? (lang: string | null) =>
+                          Boolean(lang && target.includes(lang))
+                    : (lang: string | null) => target === lang
+            factories.push({
+                context,
+                test,
+                create: rule.create,
+            })
 
             return scriptVisitor
         },

--- a/src/parser-services.ts
+++ b/src/parser-services.ts
@@ -23,6 +23,7 @@ import {
     getLang,
     parseCustomBlockElement,
 } from "./sfc/custom-block"
+import { isSFCFile, ParserOptions } from "./common/parser-options"
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -97,7 +98,7 @@ export function define(
     rootAST: ESLintProgram,
     document: VDocumentFragment | null,
     globalLocationCalculator: LocationCalculator | null,
-    { parserOptions }: { parserOptions: object },
+    { parserOptions }: { parserOptions: ParserOptions },
 ): ParserServices {
     const customBlocksEmitters = new Map<
         ESLintCustomBlockParser,
@@ -107,6 +108,8 @@ export function define(
             create: CustomBlockVisitorFactory
         }[]
     >()
+
+    const isSFC = isSFCFile(parserOptions)
 
     return {
         /**
@@ -186,6 +189,9 @@ export function define(
         ): { [key: string]: (...args: any) => void } {
             if (scriptVisitor == null) {
                 scriptVisitor = {} //eslint-disable-line no-param-reassign
+            }
+            if (!isSFC) {
+                return scriptVisitor
             }
             parserOptions = { ...parserOptions } //eslint-disable-line no-param-reassign
             const customBlocks = getCustomBlocks(document).filter(

--- a/src/parser-services.ts
+++ b/src/parser-services.ts
@@ -244,10 +244,16 @@ export function define(
                             emitter.setMaxListeners(0)
 
                             for (const factory of activeVisitorFactories) {
-                                const visitor = factory.create({
-                                    ...factory.context,
+                                const ctx = {
                                     ...customBlockContext,
-                                })
+                                }
+                                // eslint-disable-next-line @mysticatea/ts/ban-ts-ignore
+                                // @ts-ignore -- custom context
+                                ctx.__proto__ = factory.context
+
+                                const visitor = factory.create(
+                                    ctx as CustomBlockContext,
+                                )
                                 // Register handlers into the intermediate event emitter.
                                 for (const selector of Object.keys(
                                     visitor || {},

--- a/src/parser-services.ts
+++ b/src/parser-services.ts
@@ -237,6 +237,7 @@ export function define(
                                 text: sourceText,
                                 customBlock,
                                 parsedResult,
+                                globalLocationCalculator,
                                 parserOptions,
                             })
 

--- a/src/sfc/custom-block/index.ts
+++ b/src/sfc/custom-block/index.ts
@@ -1,0 +1,357 @@
+import { Rule, SourceCode } from "eslint"
+import escope, { ScopeManager, Scope } from "eslint-scope"
+import {
+    ESLintExtendedProgram,
+    getFallbackKeys,
+    Node,
+    ParseError,
+    VAttribute,
+    VDocumentFragment,
+    VElement,
+    VExpressionContainer,
+    VText,
+} from "../../ast"
+import { fixLocations } from "../../common/fix-locations"
+import { LocationCalculator } from "../../common/location-calculator"
+import { ParserOptions } from "../../common/parser-options"
+
+export interface ESLintCustomBlockParser {
+    parse(code: string, options: any): any
+    parseForESLint?(code: string, options: any): any
+}
+
+export type CustomBlockContext = {
+    getSourceCode(): SourceCode
+    parserServices: any
+    getAncestors(): any[]
+    getDeclaredVariables(node: any): any[]
+    getScope(): any
+    markVariableAsUsed(name: string): boolean
+
+    // Same as the original context.
+    id: string
+    options: any[]
+    settings: { [name: string]: any }
+    parserPath: string
+    parserOptions: any
+    getFilename(): string
+    report(descriptor: Rule.ReportDescriptor): void
+}
+
+/**
+ * Checks whether the given node is VElement.
+ */
+function isVElement(
+    node: VElement | VExpressionContainer | VText,
+): node is VElement {
+    return node.type === "VElement"
+}
+
+/**
+ * Get the all custom blocks from given document
+ * @param document
+ */
+export function getCustomBlocks(
+    document: VDocumentFragment | null,
+): VElement[] {
+    return document
+        ? document.children
+              .filter(isVElement)
+              .filter(
+                  block =>
+                      block.name !== "script" &&
+                      block.name !== "template" &&
+                      block.name !== "style",
+              )
+        : []
+}
+
+export function getLang(customBlock: VElement) {
+    return (
+        customBlock.startTag.attributes.find(
+            (attr): attr is VAttribute =>
+                !attr.directive && attr.key.name === "lang",
+        )?.value?.value || null
+    )
+}
+
+/**
+ * Parse the source code of the given custom block element.
+ * @param node The custom block element to parse.
+ * @param parser The custom parser.
+ * @param globalLocationCalculator The location calculator for fixLocations.
+ * @param parserOptions The parser options.
+ * @returns The result of parsing.
+ */
+export function parseCustomBlockElement(
+    node: VElement,
+    parser: ESLintCustomBlockParser,
+    globalLocationCalculator: LocationCalculator,
+    parserOptions: ParserOptions,
+): ESLintExtendedProgram & { error?: ParseError | Error } {
+    const text = node.children[0]
+    const offset =
+        text != null && text.type === "VText"
+            ? text.range[0]
+            : node.startTag.range[1]
+    const code = text != null && text.type === "VText" ? text.value : ""
+    const locationCalculator = globalLocationCalculator.getSubCalculatorAfter(
+        offset,
+    )
+    try {
+        return parseCustomBlockFragment(
+            code,
+            parser,
+            locationCalculator,
+            parserOptions,
+        )
+    } catch (e) {
+        return {
+            error: e,
+            ast: {
+                type: "Program",
+                sourceType: "module",
+                loc: {
+                    start: {
+                        ...node.startTag.loc.end,
+                    },
+                    end: {
+                        ...node.endTag!.loc.start,
+                    },
+                },
+                range: [node.startTag.range[1], node.endTag!.range[0]],
+                body: [],
+                tokens: [],
+                comments: [],
+                errors: [],
+            },
+        }
+    }
+}
+
+/**
+ * Parse the given source code.
+ *
+ * @param code The source code to parse.
+ * @param parser The custom parser.
+ * @param locationCalculator The location calculator for fixLocations.
+ * @param parserOptions The parser options.
+ * @returns The result of parsing.
+ */
+function parseCustomBlockFragment(
+    code: string,
+    parser: ESLintCustomBlockParser,
+    locationCalculator: LocationCalculator,
+    parserOptions: ParserOptions,
+): ESLintExtendedProgram {
+    try {
+        const result = parseBlock(code, parser, {
+            ecmaVersion: 2017,
+            loc: true,
+            range: true,
+            raw: true,
+            tokens: true,
+            comment: true,
+            eslintVisitorKeys: true,
+            eslintScopeManager: true,
+            ...parserOptions,
+        })
+        fixLocations(result, locationCalculator)
+        return result
+    } catch (err) {
+        const perr = ParseError.normalize(err)
+        if (perr) {
+            locationCalculator.fixErrorLocation(perr)
+            throw perr
+        }
+        throw err
+    }
+}
+
+function parseBlock(
+    code: string,
+    parser: ESLintCustomBlockParser,
+    parserOptions: any,
+): any {
+    const result: any =
+        typeof parser.parseForESLint === "function"
+            ? parser.parseForESLint(code, parserOptions)
+            : parser.parse(code, parserOptions)
+
+    if (result.ast != null) {
+        return result
+    }
+    return { ast: result }
+}
+
+/**
+ * Create shared context.
+ *
+ * @param text The source code of SFC.
+ * @param customBlock The custom block node.
+ * @param parsedResult The parse result data
+ * @param parserOptions The parser options.
+ */
+export function createCustomBlockSharedContext({
+    text,
+    customBlock,
+    parsedResult,
+    parserOptions,
+}: {
+    text: string
+    customBlock: VElement
+    parsedResult: ESLintExtendedProgram & { error?: ParseError | Error }
+    parserOptions: any
+}) {
+    let sourceCode: SourceCode
+    let scopeManager: ScopeManager
+    let currentNode: any
+    return {
+        serCurrentNode(node: any) {
+            currentNode = node
+        },
+        context: {
+            getAncestors: () => getAncestors(currentNode),
+
+            getDeclaredVariables: (...args: any[]) =>
+                // @ts-expect-error
+                getScopeManager().getDeclaredVariables(...args),
+            getScope: () => getScope(getScopeManager(), currentNode),
+            markVariableAsUsed: (name: string) =>
+                markVariableAsUsed(
+                    getScopeManager(),
+                    currentNode,
+                    parserOptions,
+                    name,
+                ),
+            parserServices: {
+                customBlock,
+                ...(parsedResult.services || {}),
+                ...(parsedResult.error
+                    ? { parseError: parsedResult.error }
+                    : {}),
+            },
+            getSourceCode,
+        },
+    }
+
+    function getSourceCode() {
+        return (
+            sourceCode ||
+            // eslint-disable-next-line @mysticatea/ts/no-require-imports
+            (sourceCode = new (require("eslint").SourceCode)({
+                text,
+                ast: parsedResult.ast,
+                parserServices: parsedResult.services,
+                scopeManager: getScopeManager(),
+                visitorKeys: parsedResult.visitorKeys,
+            }))
+        )
+    }
+
+    function getScopeManager() {
+        if (parsedResult.scopeManager || scopeManager) {
+            return parsedResult.scopeManager || scopeManager
+        }
+
+        const ecmaVersion = parserOptions.ecmaVersion || 2017
+        const ecmaFeatures = parserOptions.ecmaFeatures || {}
+        const sourceType = parserOptions.sourceType || "script"
+        scopeManager = escope.analyze(parsedResult.ast, {
+            ignoreEval: true,
+            nodejsScope: false,
+            impliedStrict: ecmaFeatures.impliedStrict,
+            ecmaVersion,
+            sourceType,
+            fallback: getFallbackKeys,
+        })
+        return scopeManager
+    }
+}
+
+/* The following source code is copied from `eslint/lib/linter/linter.js` */
+
+/**
+ * Gets all the ancestors of a given node
+ * @param {ASTNode} node The node
+ * @returns {ASTNode[]} All the ancestor nodes in the AST, not including the provided node, starting
+ * from the root node and going inwards to the parent node.
+ */
+function getAncestors(node: Node) {
+    const ancestorsStartingAtParent = []
+
+    for (let ancestor = node.parent; ancestor; ancestor = ancestor.parent) {
+        ancestorsStartingAtParent.push(ancestor)
+    }
+
+    return ancestorsStartingAtParent.reverse()
+}
+
+/**
+ * Gets the scope for the current node
+ * @param {ScopeManager} scopeManager The scope manager for this AST
+ * @param {ASTNode} currentNode The node to get the scope of
+ * @returns {eslint-scope.Scope} The scope information for this node
+ */
+function getScope(scopeManager: ScopeManager, currentNode: Node) {
+    // On Program node, get the outermost scope to avoid return Node.js special function scope or ES modules scope.
+    const inner = currentNode.type !== "Program"
+
+    for (
+        let node: Node | null = currentNode;
+        node;
+        node = node.parent || null
+    ) {
+        const scope = scopeManager.acquire(node as any, inner)
+
+        if (scope) {
+            if (scope.type === "function-expression-name") {
+                return scope.childScopes[0]
+            }
+            return scope
+        }
+    }
+
+    return scopeManager.scopes[0]
+}
+
+/**
+ * Marks a variable as used in the current scope
+ * @param {ScopeManager} scopeManager The scope manager for this AST. The scope may be mutated by this function.
+ * @param {ASTNode} currentNode The node currently being traversed
+ * @param {Object} parserOptions The options used to parse this text
+ * @param {string} name The name of the variable that should be marked as used.
+ * @returns {boolean} True if the variable was found and marked as used, false if not.
+ */
+function markVariableAsUsed(
+    scopeManager: ScopeManager,
+    currentNode: Node,
+    parserOptions: any,
+    name: string,
+) {
+    const hasGlobalReturn =
+        parserOptions.ecmaFeatures && parserOptions.ecmaFeatures.globalReturn
+    const specialScope =
+        hasGlobalReturn || parserOptions.sourceType === "module"
+    const currentScope = getScope(scopeManager, currentNode)
+
+    // Special Node.js scope means we need to start one level deeper
+    const initialScope =
+        currentScope.type === "global" && specialScope
+            ? currentScope.childScopes[0]
+            : currentScope
+
+    for (let scope: Scope | null = initialScope; scope; scope = scope.upper) {
+        const variable = scope.variables.find(
+            scopeVar => scopeVar.name === name,
+        )
+
+        if (variable) {
+            // @ts-expect-error
+            variable.eslintUsed = true
+            return true
+        }
+    }
+
+    return false
+}

--- a/src/sfc/custom-block/index.ts
+++ b/src/sfc/custom-block/index.ts
@@ -196,11 +196,13 @@ export function createCustomBlockSharedContext({
     text,
     customBlock,
     parsedResult,
+    globalLocationCalculator,
     parserOptions,
 }: {
     text: string
     customBlock: VElement
     parsedResult: ESLintExtendedProgram & { error?: ParseError | Error }
+    globalLocationCalculator: LocationCalculator
     parserOptions: any
 }) {
     let sourceCode: SourceCode
@@ -226,6 +228,17 @@ export function createCustomBlockSharedContext({
                 ),
             parserServices: {
                 customBlock,
+                parseCustomBlockElement(
+                    parser: ESLintCustomBlockParser,
+                    options: any,
+                ) {
+                    return parseCustomBlockElement(
+                        customBlock,
+                        parser,
+                        globalLocationCalculator,
+                        { ...parserOptions, ...options },
+                    )
+                },
                 ...(parsedResult.services || {}),
                 ...(parsedResult.error
                     ? { parseError: parsedResult.error }

--- a/test/define-custom-blocks-visitor.js
+++ b/test/define-custom-blocks-visitor.js
@@ -1,0 +1,563 @@
+/**
+ * @author Yosuke Ota <https://github.com/ota-meshi>
+ */
+"use strict"
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const assert = require("assert")
+const path = require("path")
+const eslint = require("eslint")
+const jsonParser = require("jsonc-eslint-parser")
+const espree = require("espree")
+const Linter = eslint.Linter
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+const PARSER_PATH = path.resolve(__dirname, "../src/index.ts")
+
+const LINTER_CONFIG = {
+    parser: PARSER_PATH,
+    parserOptions: {
+        ecmaVersion: 2018,
+    },
+    rules: {
+        "test-no-number-literal": "error",
+        "test-no-forbidden-key": "error",
+        "test-no-parsing-error": "error",
+    },
+}
+const noNumberLiteralRule = {
+    create(context) {
+        let count = 0
+        return {
+            JSONLiteral(node) {
+                if (typeof node.value === "number") {
+                    context.report({
+                        node,
+                        message: `OK ${node.value}@count:${++count}`,
+                    })
+                }
+            },
+        }
+    },
+}
+const noNoForbiddenKeyRule = {
+    create(context) {
+        return {
+            'JSONProperty > JSONLiteral[value="forbidden"]'(node) {
+                if (node.parent.key === node) {
+                    context.report({
+                        node,
+                        message: 'no "forbidden" key',
+                    })
+                }
+            },
+        }
+    },
+}
+const noParsingErrorRule = {
+    create(context) {
+        const parseError = context.parserServices.parseError
+        if (parseError) {
+            let loc = undefined
+            if ("column" in parseError && "lineNumber" in parseError) {
+                loc = {
+                    line: parseError.lineNumber,
+                    column: parseError.column,
+                }
+            }
+            return {
+                Program(node) {
+                    context.report({
+                        node,
+                        loc,
+                        message: parseError.message,
+                    })
+                },
+            }
+        }
+        return {}
+    },
+}
+const noProgramExitRule = {
+    create(context) {
+        return {
+            "Program:exit"(node) {
+                context.report({
+                    node,
+                    message: "Program:exit",
+                })
+            },
+        }
+    },
+}
+
+function createLinter(target = "json") {
+    const linter = new Linter()
+
+    linter.defineParser(PARSER_PATH, require(PARSER_PATH))
+    linter.defineRule("test-no-number-literal", context =>
+        context.parserServices.defineCustomBlocksVisitor(context, jsonParser, {
+            target,
+            ...noNumberLiteralRule,
+        })
+    )
+    linter.defineRule("test-no-forbidden-key", context =>
+        context.parserServices.defineCustomBlocksVisitor(context, jsonParser, {
+            target,
+            ...noNoForbiddenKeyRule,
+        })
+    )
+    linter.defineRule("test-no-parsing-error", context =>
+        context.parserServices.defineCustomBlocksVisitor(context, jsonParser, {
+            target,
+            ...noParsingErrorRule,
+        })
+    )
+    linter.defineRule("test-no-parsing-error", context =>
+        context.parserServices.defineCustomBlocksVisitor(context, jsonParser, {
+            target,
+            ...noParsingErrorRule,
+        })
+    )
+    linter.defineRule("test-no-program-exit", context =>
+        context.parserServices.defineCustomBlocksVisitor(
+            context,
+            jsonParser,
+            {
+                target,
+                ...noProgramExitRule,
+            },
+            noProgramExitRule.create(context)
+        )
+    )
+
+    return linter
+}
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("parserServices.defineCustomBlocksVisitor tests", () => {
+    it("should work even if AST object was reused.", () => {
+        const code = `
+<i18n lang="json">
+{"forbidden": 42}
+</i18n>`
+
+        const linter = createLinter()
+        const messages1 = linter.verify(code, LINTER_CONFIG)
+        const messages2 = linter.verify(linter.getSourceCode(), LINTER_CONFIG)
+
+        assert.strictEqual(messages1.length, 2)
+        assert.strictEqual(messages1[0].message, 'no "forbidden" key')
+        assert.strictEqual(messages1[1].message, "OK 42@count:1")
+        assert.strictEqual(messages1[1].line, 3)
+        assert.strictEqual(messages1[1].column, 15)
+        assert.strictEqual(messages1[1].endColumn, 17)
+        assert.strictEqual(messages2.length, 2)
+        assert.strictEqual(messages2[0].message, 'no "forbidden" key')
+        assert.strictEqual(messages2[1].message, "OK 42@count:1")
+    })
+
+    it("should work even if multiple blocks.", () => {
+        const code = `
+<i18n lang="json">
+{"foo": 42}
+</i18n>
+<i18n lang="json5">
+{"foo": 123}
+</i18n>
+`
+        const linter = createLinter(["json", "json5"])
+
+        const messages = linter.verify(code, LINTER_CONFIG)
+
+        assert.strictEqual(messages.length, 2)
+        assert.strictEqual(messages[0].message, "OK 42@count:1")
+        assert.strictEqual(messages[0].line, 3)
+        assert.strictEqual(messages[0].column, 9)
+        assert.strictEqual(messages[0].endColumn, 11)
+        assert.strictEqual(messages[1].message, "OK 123@count:1")
+        assert.strictEqual(messages[1].line, 6)
+        assert.strictEqual(messages[1].column, 9)
+        assert.strictEqual(messages[1].endColumn, 12)
+    })
+
+    it("should ignore standard blocks.", () => {
+        const code = `
+<template lang="json">
+{"foo": 42}
+</template>
+<style lang="json">
+{"foo": 123}
+</style>
+`
+        const linter = createLinter()
+
+        const messages = linter.verify(code, LINTER_CONFIG)
+
+        assert.strictEqual(messages.length, 0)
+    })
+
+    it("should ignore linked blocks.", () => {
+        const code = `
+<i18n lang="json" src="./foo.json">
+{"foo": 42}
+</i18n>
+`
+        const linter = createLinter()
+
+        const messages = linter.verify(code, LINTER_CONFIG)
+
+        assert.strictEqual(messages.length, 0)
+    })
+    it("should ignore un closed blocks.", () => {
+        const code = `
+<i18n lang="json">
+{"foo": 42}
+`
+        const linter = createLinter()
+
+        const messages = linter.verify(code, LINTER_CONFIG)
+
+        assert.strictEqual(messages.length, 0)
+    })
+
+    it("should ignore not target blocks.", () => {
+        const code = `
+<i18n lang="yaml">
+"foo": 42
+</i18n>
+<i18n lang="yml">
+"foo": 42
+</i18n>
+<docs>
+"foo": 42
+</docs>
+`
+        const linter = createLinter(
+            (lang, block) =>
+                (lang === "json" && lang === "json5") ||
+                (!lang && block.name === "i18n")
+        )
+
+        const messages1 = linter.verify(code, LINTER_CONFIG)
+
+        assert.strictEqual(messages1.length, 0)
+        const messages2 = linter.verify(
+            `${code}<i18n>123</i18n>`,
+            LINTER_CONFIG
+        )
+
+        assert.strictEqual(messages2.length, 1)
+    })
+
+    it("should work even if parse error.", () => {
+        const code = `
+<i18n lang="json">
+"foo": 42
+</i18n>
+<i18n lang="json"></i18n>
+<i18n lang="json">
+</i18n>
+`
+        const linter = createLinter()
+
+        const messages = linter.verify(code, LINTER_CONFIG)
+
+        assert.strictEqual(messages.length, 3)
+        assert.strictEqual(messages[0].message, "Unexpected token :")
+        assert.strictEqual(messages[0].line, 3)
+        assert.strictEqual(messages[0].column, 6)
+        assert.strictEqual(messages[1].message, "Unexpected end of expression.")
+        assert.strictEqual(messages[1].line, 5)
+        assert.strictEqual(messages[1].column, 19)
+        assert.strictEqual(
+            messages[2].message,
+            "Expected to be an expression, but got empty."
+        )
+        assert.strictEqual(messages[2].line, 6)
+        assert.strictEqual(messages[2].column, 19)
+    })
+
+    it("should work even if error.", () => {
+        const code = `
+<i18n lang="json">
+{ "foo": 42 }
+</i18n>
+<i18n lang="yaml">
+"foo" 42
+</i18n>
+`
+        const linter = createLinter()
+        linter.defineRule("test-no-yml-parsing-error", context =>
+            context.parserServices.defineCustomBlocksVisitor(
+                context,
+                {
+                    parse() {
+                        throw new Error("Foo")
+                    },
+                },
+                {
+                    target: "yaml",
+                    ...noParsingErrorRule,
+                }
+            )
+        )
+
+        const messages = linter.verify(code, {
+            ...LINTER_CONFIG,
+            rules: {
+                ...LINTER_CONFIG.rules,
+                "test-no-yml-parsing-error": "error",
+            },
+        })
+
+        assert.strictEqual(messages.length, 2)
+        assert.strictEqual(messages[0].message, "OK 42@count:1")
+        assert.strictEqual(messages[0].line, 3)
+        assert.strictEqual(messages[0].column, 10)
+        assert.strictEqual(messages[0].endColumn, 12)
+        assert.strictEqual(messages[1].message, "Foo")
+        assert.strictEqual(messages[1].line, 5)
+        assert.strictEqual(messages[1].column, 19)
+    })
+    it("should work even with scriptVisitor().", () => {
+        const code = `
+<i18n lang="json">
+{ "foo": 42 }
+</i18n>
+`
+        const linter = createLinter()
+
+        const messages = linter.verify(code, {
+            ...LINTER_CONFIG,
+            rules: {
+                "test-no-program-exit": "error",
+                ...LINTER_CONFIG.rules,
+            },
+        })
+
+        assert.strictEqual(messages.length, 3)
+        assert.strictEqual(messages[0].message, "Program:exit")
+        assert.strictEqual(messages[0].line, 1)
+        assert.strictEqual(messages[0].column, 1)
+        assert.strictEqual(messages[1].message, "Program:exit")
+        assert.strictEqual(messages[1].line, 2)
+        assert.strictEqual(messages[1].column, 19)
+        assert.strictEqual(messages[2].message, "OK 42@count:1")
+    })
+
+    describe("API tests", () => {
+        it("should work getAncestors().", () => {
+            const code = `
+<i18n lang="json">
+{ "foo": { "bar": "target" } }
+</i18n>
+`
+            const linter = createLinter()
+            linter.defineRule("test", context =>
+                context.parserServices.defineCustomBlocksVisitor(
+                    context,
+                    jsonParser,
+                    {
+                        target: "json",
+                        create(customBlockContext) {
+                            return {
+                                "JSONLiteral[value='target']"(node) {
+                                    customBlockContext.report({
+                                        node,
+                                        message: JSON.stringify(
+                                            customBlockContext
+                                                .getAncestors()
+                                                .map(n => n.type)
+                                        ),
+                                    })
+                                },
+                            }
+                        },
+                    }
+                )
+            )
+
+            const messages = linter.verify(code, {
+                ...LINTER_CONFIG,
+                rules: {
+                    ...LINTER_CONFIG.rules,
+                    test: "error",
+                },
+            })
+
+            assert.strictEqual(messages.length, 1)
+            assert.strictEqual(
+                messages[0].message,
+                '["Program","JSONExpressionStatement","JSONObjectExpression","JSONProperty","JSONObjectExpression","JSONProperty"]'
+            )
+        })
+        it("should work getSourceCode().", () => {
+            const code = `
+<i18n lang="json">
+{ "foo": { "bar": "target" } }
+</i18n>
+`
+            const linter = createLinter()
+            linter.defineRule("test", context =>
+                context.parserServices.defineCustomBlocksVisitor(
+                    context,
+                    jsonParser,
+                    {
+                        target: "json",
+                        create(customBlockContext) {
+                            return {
+                                "JSONLiteral[value='target']"(node) {
+                                    customBlockContext.report({
+                                        node,
+                                        message: JSON.stringify(
+                                            customBlockContext
+                                                .getSourceCode()
+                                                .getLocFromIndex(node.range[0])
+                                        ),
+                                    })
+                                },
+                            }
+                        },
+                    }
+                )
+            )
+
+            const messages = linter.verify(code, {
+                ...LINTER_CONFIG,
+                rules: {
+                    ...LINTER_CONFIG.rules,
+                    test: "error",
+                },
+            })
+
+            assert.strictEqual(messages.length, 1)
+            assert.strictEqual(messages[0].message, '{"line":3,"column":18}')
+            assert.strictEqual(messages[0].line, 3)
+            assert.strictEqual(messages[0].column, 19)
+        })
+
+        it("should work markVariableAsUsed().", () => {
+            const code = `
+<js lang="js">
+let a = 42;
+</js>
+`
+            const linter = createLinter()
+            const rule = linter.getRules().get("no-unused-vars")
+            linter.defineRule("test-no-unused-vars", {
+                ...rule,
+                create(context) {
+                    return context.parserServices.defineCustomBlocksVisitor(
+                        context,
+                        espree,
+                        {
+                            target: "js",
+                            create(customBlockContext) {
+                                return rule.create(customBlockContext)
+                            },
+                        }
+                    )
+                },
+            })
+            linter.defineRule("test-mark-vars", {
+                create(context) {
+                    return context.parserServices.defineCustomBlocksVisitor(
+                        context,
+                        espree,
+                        {
+                            target: "js",
+                            create(customBlockContext) {
+                                return {
+                                    Literal() {
+                                        customBlockContext.markVariableAsUsed(
+                                            "a"
+                                        )
+                                        customBlockContext.markVariableAsUsed(
+                                            "b"
+                                        )
+                                    },
+                                }
+                            },
+                        }
+                    )
+                },
+            })
+
+            const messages1 = linter.verify(code, {
+                ...LINTER_CONFIG,
+                rules: {
+                    ...LINTER_CONFIG.rules,
+                    "test-no-unused-vars": "error",
+                },
+            })
+
+            assert.strictEqual(messages1.length, 1)
+            assert.strictEqual(
+                messages1[0].message,
+                "'a' is assigned a value but never used."
+            )
+
+            const messages2 = linter.verify(code, {
+                ...LINTER_CONFIG,
+                rules: {
+                    ...LINTER_CONFIG.rules,
+                    "test-no-unused-vars": "error",
+                    "test-mark-vars": "error",
+                },
+            })
+
+            assert.strictEqual(messages2.length, 0)
+        })
+
+        it("should work getDeclaredVariables().", () => {
+            const code = `
+<js lang="js">
+function a(arg) {
+    arg = 42
+}
+</js>
+`
+            const linter = createLinter()
+            const rule = linter.getRules().get("no-param-reassign")
+            linter.defineRule("test-no-param-reassign", {
+                ...rule,
+                create(context) {
+                    return context.parserServices.defineCustomBlocksVisitor(
+                        context,
+                        espree,
+                        {
+                            target: "js",
+                            create(customBlockContext) {
+                                return rule.create(customBlockContext)
+                            },
+                        }
+                    )
+                },
+            })
+
+            const messages1 = linter.verify(code, {
+                ...LINTER_CONFIG,
+                rules: {
+                    ...LINTER_CONFIG.rules,
+                    "test-no-param-reassign": "error",
+                },
+            })
+
+            assert.strictEqual(messages1.length, 1)
+            assert.strictEqual(
+                messages1[0].message,
+                "Assignment to function parameter 'arg'."
+            )
+        })
+    })
+})

--- a/test/define-custom-blocks-visitor.js
+++ b/test/define-custom-blocks-visitor.js
@@ -259,6 +259,19 @@ describe("parserServices.defineCustomBlocksVisitor tests", () => {
         assert.strictEqual(messages2.length, 1)
     })
 
+    it("should ignore html.", () => {
+        const code = `
+<i18n lang="json">
+{ "foo": 42 }
+</i18n>
+`
+        const linter = createLinter()
+
+        const messages = linter.verify(code, LINTER_CONFIG, "test.html")
+
+        assert.strictEqual(messages.length, 0)
+    })
+
     it("should work even if parse error.", () => {
         const code = `
 <i18n lang="json">

--- a/test/fixtures/document-fragment/empty-custom-block/document-fragment.json
+++ b/test/fixtures/document-fragment/empty-custom-block/document-fragment.json
@@ -1,0 +1,189 @@
+{
+    "type": "VDocumentFragment",
+    "range": [
+        0,
+        30
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 2,
+            "column": 0
+        }
+    },
+    "children": [
+        {
+            "type": "VElement",
+            "range": [
+                0,
+                29
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 29
+                }
+            },
+            "name": "custom-block",
+            "rawName": "custom-block",
+            "namespace": "http://www.w3.org/1999/xhtml",
+            "startTag": {
+                "type": "VStartTag",
+                "range": [
+                    0,
+                    14
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 14
+                    }
+                },
+                "selfClosing": false,
+                "attributes": []
+            },
+            "children": [],
+            "endTag": {
+                "type": "VEndTag",
+                "range": [
+                    14,
+                    29
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 14
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 29
+                    }
+                }
+            },
+            "variables": []
+        },
+        {
+            "type": "VText",
+            "range": [
+                29,
+                30
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 29
+                },
+                "end": {
+                    "line": 2,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        }
+    ],
+    "tokens": [
+        {
+            "type": "HTMLTagOpen",
+            "range": [
+                0,
+                13
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            },
+            "value": "custom-block"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                13,
+                14
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 13
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLEndTagOpen",
+            "range": [
+                14,
+                28
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 14
+                },
+                "end": {
+                    "line": 1,
+                    "column": 28
+                }
+            },
+            "value": "custom-block"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                28,
+                29
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 28
+                },
+                "end": {
+                    "line": 1,
+                    "column": 29
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                29,
+                30
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 29
+                },
+                "end": {
+                    "line": 2,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        }
+    ],
+    "comments": [],
+    "errors": []
+}

--- a/test/fixtures/document-fragment/empty-custom-block/source.vue
+++ b/test/fixtures/document-fragment/empty-custom-block/source.vue
@@ -1,0 +1,1 @@
+<custom-block></custom-block>

--- a/test/fixtures/document-fragment/empty-custom-block/token-ranges.json
+++ b/test/fixtures/document-fragment/empty-custom-block/token-ranges.json
@@ -1,0 +1,7 @@
+[
+    "<custom-block",
+    ">",
+    "</custom-block",
+    ">",
+    "\n"
+]

--- a/test/fixtures/document-fragment/empty-custom-block/tree.json
+++ b/test/fixtures/document-fragment/empty-custom-block/tree.json
@@ -1,0 +1,29 @@
+[
+    {
+        "type": "VDocumentFragment",
+        "text": "<custom-block></custom-block>\n",
+        "children": [
+            {
+                "type": "VElement",
+                "text": "<custom-block></custom-block>",
+                "children": [
+                    {
+                        "type": "VStartTag",
+                        "text": "<custom-block>",
+                        "children": []
+                    },
+                    {
+                        "type": "VEndTag",
+                        "text": "</custom-block>",
+                        "children": []
+                    }
+                ]
+            },
+            {
+                "type": "VText",
+                "text": "\n",
+                "children": []
+            }
+        ]
+    }
+]

--- a/test/index.js
+++ b/test/index.js
@@ -603,7 +603,7 @@ describe("Basic tests", () => {
             assert.strictEqual(messages1.length, 1)
             assert.strictEqual(messages1[0].message, "OK")
             assert.strictEqual(messages2.length, 1)
-            assert.strictEqual(messages1[0].message, "OK")
+            assert.strictEqual(messages2[0].message, "OK")
         })
     })
 })


### PR DESCRIPTION
This PR adds `defineCustomBlocksVisitor()` to parserServices.

You can easily create rules to parse and validate custom blocks using `defineCustomBlocksVisitor()` API.

I plan to use this API to modify the rules of [eslint-plugin-jsonc](https://github.com/ota-meshi/eslint-plugin-jsonc) and [eslint-plugin-yml](https://github.com/ota-meshi/eslint-plugin-yml) to apply them to SFC custom blocks.
Also, [eslint-plugin-vue-i18n](https://github.com/intlify/eslint-plugin-vue-i18n) can be refactored using this API.
