### PR TITLE
Add support for parser object to `parserOptions.parser`

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,26 @@ You can also specify an object and change the parser separately for `<script lan
 }
 ```
 
+When using JavaScript configuration (`.eslintrc.js`), you can also give the parser object directly.
+
+```js
+const tsParser = require("@typescript-eslint/parser")
+const espree = require("espree")
+
+module.exports = {
+    parser: "vue-eslint-parser",
+    parserOptions: {
+        // Single parser
+        parser: tsParser,
+        // Multiple parser
+        parser: {
+            js: espree,
+            ts: tsParser,
+        }
+    },
+}
+```
+
 If the `parserOptions.parser` is `false`, the `vue-eslint-parser` skips parsing `<script>` tags completely.
 This is useful for people who use the language ESLint community doesn't provide custom parser implementation.
 

--- a/src/common/espree.ts
+++ b/src/common/espree.ts
@@ -1,4 +1,3 @@
-import type { ESLintExtendedProgram, ESLintProgram } from "../ast"
 import type { ParserOptions } from "../common/parser-options"
 import { getLinterRequire } from "./linter-require"
 // @ts-expect-error -- ignore
@@ -6,20 +5,9 @@ import * as dependencyEspree from "espree"
 import { lte, lt } from "semver"
 import { createRequire } from "./create-require"
 import path from "path"
+import type { BasicParserObject } from "./parser-object"
 
-/**
- * The interface of a result of ESLint custom parser.
- */
-export type ESLintCustomParserResult = ESLintProgram | ESLintExtendedProgram
-
-/**
- * The interface of ESLint custom parsers.
- */
-export interface ESLintCustomParser {
-    parse(code: string, options: any): ESLintCustomParserResult
-    parseForESLint?(code: string, options: any): ESLintCustomParserResult
-}
-type Espree = ESLintCustomParser & {
+type Espree = BasicParserObject & {
     latestEcmaVersion?: number
     version: string
 }

--- a/src/common/parser-object.ts
+++ b/src/common/parser-object.ts
@@ -1,0 +1,30 @@
+import type { ESLintExtendedProgram, ESLintProgram } from "../ast"
+
+export type BasicParserObject<R = ESLintProgram> = {
+    parse(code: string, options: any): R
+    parseForESLint: undefined
+}
+export type EnhancedParserObject<R = ESLintExtendedProgram> = {
+    parseForESLint(code: string, options: any): R
+    parse: undefined
+}
+
+export type ParserObject<R1 = ESLintExtendedProgram, R2 = ESLintProgram> =
+    | EnhancedParserObject<R1>
+    | BasicParserObject<R2>
+
+export function isParserObject<R1, R2>(
+    value: ParserObject<R1, R2> | {} | undefined | null,
+): value is ParserObject<R1, R2> {
+    return isEnhancedParserObject(value) || isBasicParserObject(value)
+}
+export function isEnhancedParserObject<R>(
+    value: EnhancedParserObject<R> | {} | undefined | null,
+): value is EnhancedParserObject<R> {
+    return Boolean(value && typeof (value as any).parseForESLint === "function")
+}
+export function isBasicParserObject<R>(
+    value: BasicParserObject<R> | {} | undefined | null,
+): value is BasicParserObject<R> {
+    return Boolean(value && typeof (value as any).parse === "function")
+}

--- a/src/common/parser-options.ts
+++ b/src/common/parser-options.ts
@@ -1,10 +1,16 @@
 import * as path from "path"
 import type { VDocumentFragment } from "../ast"
 import { getLang, isScriptElement, isScriptSetupElement } from "./ast-utils"
+import type { ParserObject } from "./parser-object"
+import { isParserObject } from "./parser-object"
 
 export interface ParserOptions {
     // vue-eslint-parser options
-    parser?: boolean | string
+    parser?:
+        | boolean
+        | string
+        | ParserObject
+        | Record<string, string | ParserObject | undefined>
     vueFeatures?: {
         interpolationAsNonHTML?: boolean // default true
         filter?: boolean // default true
@@ -55,9 +61,17 @@ export function isSFCFile(parserOptions: ParserOptions) {
  * Gets the script parser name from the given parser lang.
  */
 export function getScriptParser(
-    parser: boolean | string | Record<string, string | undefined> | undefined,
+    parser:
+        | boolean
+        | string
+        | ParserObject
+        | Record<string, string | ParserObject | undefined>
+        | undefined,
     getParserLang: () => string | null | Iterable<string | null>,
-): string | undefined {
+): string | ParserObject | undefined {
+    if (isParserObject(parser)) {
+        return parser
+    }
     if (parser && typeof parser === "object") {
         const parserLang = getParserLang()
         const parserLangs =
@@ -68,7 +82,10 @@ export function getScriptParser(
                 : parserLang
         for (const lang of parserLangs) {
             const parserForLang = lang && parser[lang]
-            if (typeof parserForLang === "string") {
+            if (
+                typeof parserForLang === "string" ||
+                isParserObject(parserForLang)
+            ) {
                 return parserForLang
             }
         }

--- a/src/script/index.ts
+++ b/src/script/index.ts
@@ -42,7 +42,6 @@ import {
     analyzeExternalReferences,
     analyzeVariablesAndExternalReferences,
 } from "./scope-analyzer"
-import type { ESLintCustomParser } from "../common/espree"
 import {
     getEcmaVersionIfUseEspree,
     getEspreeFromUser,
@@ -60,6 +59,8 @@ import {
 } from "../script-setup/parser-options"
 import { isScriptSetupElement } from "../common/ast-utils"
 import type { LinesAndColumns } from "../common/lines-and-columns"
+import type { ParserObject } from "../common/parser-object"
+import { isEnhancedParserObject, isParserObject } from "../common/parser-object"
 
 // [1] = aliases.
 // [2] = delimiter.
@@ -545,15 +546,16 @@ export function parseScript(
     code: string,
     parserOptions: ParserOptions,
 ): ESLintExtendedProgram {
-    const parser: ESLintCustomParser =
+    const parser: ParserObject =
         typeof parserOptions.parser === "string"
             ? loadParser(parserOptions.parser)
+            : isParserObject(parserOptions.parser)
+            ? parserOptions.parser
             : getEspreeFromEcmaVersion(parserOptions.ecmaVersion)
 
-    const result: any =
-        typeof parser.parseForESLint === "function"
-            ? parser.parseForESLint(code, parserOptions)
-            : parser.parse(code, parserOptions)
+    const result: any = isEnhancedParserObject(parser)
+        ? parser.parseForESLint(code, parserOptions)
+        : parser.parse(code, parserOptions)
 
     if (result.ast != null) {
         return result

--- a/src/sfc/custom-block/index.ts
+++ b/src/sfc/custom-block/index.ts
@@ -14,13 +14,12 @@ import { getEslintScope } from "../../common/eslint-scope"
 import { getEcmaVersionIfUseEspree } from "../../common/espree"
 import { fixErrorLocation, fixLocations } from "../../common/fix-locations"
 import type { LocationCalculatorForHtml } from "../../common/location-calculator"
+import type { ParserObject } from "../../common/parser-object"
+import { isEnhancedParserObject } from "../../common/parser-object"
 import type { ParserOptions } from "../../common/parser-options"
 import { DEFAULT_ECMA_VERSION } from "../../script-setup/parser-options"
 
-export interface ESLintCustomBlockParser {
-    parse(code: string, options: any): any
-    parseForESLint?(code: string, options: any): any
-}
+export type ESLintCustomBlockParser = ParserObject<any, any>
 
 export type CustomBlockContext = {
     getSourceCode(): SourceCode
@@ -181,10 +180,9 @@ function parseBlock(
     parser: ESLintCustomBlockParser,
     parserOptions: any,
 ): any {
-    const result: any =
-        typeof parser.parseForESLint === "function"
-            ? parser.parseForESLint(code, parserOptions)
-            : parser.parse(code, parserOptions)
+    const result = isEnhancedParserObject(parser)
+        ? parser.parseForESLint(code, parserOptions)
+        : parser.parse(code, parserOptions)
 
     if (result.ast != null) {
         return result

--- a/test/index.js
+++ b/test/index.js
@@ -308,6 +308,46 @@ describe("Basic tests", () => {
                 assert.deepStrictEqual(report[0].messages, [])
                 assert.deepStrictEqual(report[1].messages, [])
             })
+
+            it("should notify no error with parser object with '@typescript-eslint/parser'", async () => {
+                const cli = new ESLint({
+                    cwd: FIXTURE_DIR,
+                    overrideConfig: {
+                        env: { es6: true, node: true },
+                        parser: PARSER_PATH,
+                        parserOptions: {
+                            parser: require("@typescript-eslint/parser"),
+                        },
+                        rules: { semi: ["error", "never"] },
+                    },
+                    useEslintrc: false,
+                })
+                const report = await cli.lintFiles(["typed.js"])
+                const messages = report[0].messages
+
+                assert.deepStrictEqual(messages, [])
+            })
+
+            it("should notify no error with multiple parser object with '@typescript-eslint/parser'", async () => {
+                const cli = new ESLint({
+                    cwd: FIXTURE_DIR,
+                    overrideConfig: {
+                        env: { es6: true, node: true },
+                        parser: PARSER_PATH,
+                        parserOptions: {
+                            parser: {
+                                ts: require("@typescript-eslint/parser"),
+                            },
+                        },
+                        rules: { semi: ["error", "never"] },
+                    },
+                    useEslintrc: false,
+                })
+                const report = await cli.lintFiles(["typed.ts", "typed.tsx"])
+
+                assert.deepStrictEqual(report[0].messages, [])
+                assert.deepStrictEqual(report[1].messages, [])
+            })
         }
     })
 


### PR DESCRIPTION
This PR changes `parserOptions.parser` to allow you to directly specify a parser object.

As background, ESLint core is planning a new flat configuration.
https://eslint.org/blog/2022/08/new-config-system-part-1/

The new configuration allows you to specify parser objects directly.
https://eslint.org/blog/2022/08/new-config-system-part-2/#custom-parsers-and-parser-options-are-mostly-the-same

For this reason, there is a possibility that parsers that do not assume module name specification as before will appear.
The changes in this PR are intended to follow the new parser specification method.