### PR TITLE
Remove david-dm from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Downloads/month](https://img.shields.io/npm/dm/vue-eslint-parser.svg)](http://www.npmtrends.com/vue-eslint-parser)
 [![Build Status](https://github.com/vuejs/vue-eslint-parser/workflows/CI/badge.svg)](https://github.com/vuejs/vue-eslint-parser/actions)
 [![Coverage Status](https://codecov.io/gh/vuejs/vue-eslint-parser/branch/master/graph/badge.svg)](https://codecov.io/gh/vuejs/vue-eslint-parser)
-[![Dependency Status](https://david-dm.org/vuejs/vue-eslint-parser.svg)](https://david-dm.org/vuejs/vue-eslint-parser)
 
 The ESLint custom parser for `.vue` files.
 


### PR DESCRIPTION
The `david-dm.org` website is down for 3 months, and the project `alanshaw/david` is not actively maintained anymore. `david-dm.org` should be considered dead, thus badges should be removed from README.