### PR TITLE
Add exported meta object

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.60.0",
     "rollup-plugin-node-resolve": "^5.2.0",
+    "rollup-plugin-replace": "^2.2.0",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "ts-node": "^10.4.0",
     "typescript": "~4.8.4",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,7 @@
  */
 import resolve from "rollup-plugin-node-resolve"
 import sourcemaps from "rollup-plugin-sourcemaps"
+import replace from "rollup-plugin-replace"
 
 const pkg = require("./package.json")
 const deps = new Set(
@@ -23,6 +24,12 @@ export default {
  * See LICENSE file in root directory for full license.
  */`,
     },
-    plugins: [sourcemaps(), resolve()],
+    plugins: [
+        sourcemaps(),
+        resolve(),
+        replace({
+            "process.env.PACKAGE_VERSION": `"${pkg.version}"`,
+        }),
+    ],
     external: id => deps.has(id) || id.startsWith("lodash"),
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,7 +211,6 @@ function parseAsScript(code: string, options: ParserOptions) {
 
 export const meta = {
     name: "vue-eslint-parser",
-    // Bundled index.js is output to the same package root directory as package.json
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    version: require("./package.json").version,
+    // eslint-disable-next-line no-process-env
+    version: process.env.PACKAGE_VERSION,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -208,3 +208,9 @@ function parseAsScript(code: string, options: ParserOptions) {
         }),
     })
 }
+
+export const meta = {
+    name: "vue-eslint-parser",
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    version: require("../package.json"),
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,6 +211,7 @@ function parseAsScript(code: string, options: ParserOptions) {
 
 export const meta = {
     name: "vue-eslint-parser",
+    // Bundled index.js is output to the same package root directory as package.json
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    version: require("../package.json"),
+    version: require("./package.json").version,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -213,4 +213,4 @@ export const meta = {
     name: "vue-eslint-parser",
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     version: require("../package.json"),
-};
+}


### PR DESCRIPTION
Related issue: nothing

This PR’s purpose is to support ESLint flat config.

Loading vue-eslint-parser in flat config, ESLint check parser’s name and version in meta object.
https://github.com/eslint/eslint/blob/main/lib/config/flat-config-array.js#L196
https://github.com/eslint/eslint/blob/main/lib/config/flat-config-array.js#L45-L76

vue-eslint-parser can be used in the flat config by exporting the meta object like other packages:
- https://github.com/typescript-eslint/typescript-eslint/pull/6586
- https://github.com/babel/babel/pull/15465