### PR TITLE
Make to use `project: undefined` when parsing script-fragments in `<template>`.

### DIFF
--- a/src/common/parser-options.ts
+++ b/src/common/parser-options.ts
@@ -30,6 +30,7 @@ export interface ParserOptions {
     lib?: string[]
 
     project?: string | string[]
+    projectService?: boolean | ProjectServiceOptions
     projectFolderIgnoreList?: string[]
     tsconfigRootDir?: string
     extraFileExtensions?: string[]
@@ -53,6 +54,13 @@ export interface ParserOptions {
         string,
         string | CustomTemplateTokenizerConstructor | undefined
     >
+}
+
+interface ProjectServiceOptions {
+    allowDefaultProject?: string[]
+    defaultProject?: string
+    loadTypeScriptPlugins?: boolean
+    maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING?: number
 }
 
 export function isSFCFile(parserOptions: ParserOptions) {

--- a/src/html/parser.ts
+++ b/src/html/parser.ts
@@ -302,6 +302,7 @@ export class Parser {
                     yield getParserLangFromSFC(doc)
                 },
             ),
+            project: undefined,
         }
         const scriptParserOptions = {
             ...this.baseParserOptions,

--- a/src/html/parser.ts
+++ b/src/html/parser.ts
@@ -303,6 +303,7 @@ export class Parser {
                 },
             ),
             project: undefined,
+            projectService: undefined,
         }
         const scriptParserOptions = {
             ...this.baseParserOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,7 @@ function parseAsSFC(code: string, options: ParserOptions) {
                 yield getParserLangFromSFC(rootAST)
             }),
             project: undefined,
+            projectService: undefined,
         })
     }
     result.ast.templateBody = templateBody

--- a/src/index.ts
+++ b/src/index.ts
@@ -165,6 +165,7 @@ function parseAsSFC(code: string, options: ParserOptions) {
                 yield "<template>"
                 yield getParserLangFromSFC(rootAST)
             }),
+            project: undefined,
         })
     }
     result.ast.templateBody = templateBody

--- a/src/script-setup/index.ts
+++ b/src/script-setup/index.ts
@@ -516,13 +516,11 @@ function getScriptSetupCodeBlocks(
     const offsetLocationCalculator =
         linesAndColumns.createOffsetLocationCalculator(scriptSetupStartOffset)
 
-    const result = parseScript(
+    const { ast, visitorKeys } = parseScript(
         scriptCode,
-        parserOptions,
+        { ...parserOptions, project: undefined },
         offsetLocationCalculator,
     )
-
-    const { ast } = result
 
     // Holds the `import` and re-`export` statements.
     // All import and re-`export` statements are hoisted to the top.
@@ -597,7 +595,7 @@ function getScriptSetupCodeBlocks(
                         }
                         fixNodeLocations(
                             body,
-                            result.visitorKeys,
+                            visitorKeys,
                             offsetLocationCalculator,
                         )
                         fixLocation(exportToken, offsetLocationCalculator)
@@ -695,7 +693,7 @@ function getScriptSetupCodeBlocks(
                         // restore
                         fixNodeLocations(
                             body,
-                            result.visitorKeys,
+                            visitorKeys,
                             offsetLocationCalculator,
                         )
                         for (const token of restoreTokens) {
@@ -826,7 +824,7 @@ function getScriptSetupCodeBlocks(
         let start = n.range[0]
         let end = n.range[1]
         traverseNodes(n, {
-            visitorKeys: result.visitorKeys,
+            visitorKeys,
             enterNode(c) {
                 start = Math.min(start, c.range[0])
                 end = Math.max(end, c.range[1])

--- a/src/script-setup/index.ts
+++ b/src/script-setup/index.ts
@@ -518,7 +518,7 @@ function getScriptSetupCodeBlocks(
 
     const { ast, visitorKeys } = parseScript(
         scriptCode,
-        { ...parserOptions, project: undefined },
+        { ...parserOptions, project: undefined, projectService: undefined },
         offsetLocationCalculator,
     )
 

--- a/src/script-setup/parser-options.ts
+++ b/src/script-setup/parser-options.ts
@@ -16,7 +16,7 @@ export function getScriptSetupParserOptions(
 
     return {
         ...parserOptions,
-        ecmaVersion: espreeEcmaVersion,
+        ecmaVersion: espreeEcmaVersion || parserOptions.ecmaVersion,
     }
 }
 

--- a/src/script/index.ts
+++ b/src/script/index.ts
@@ -1302,7 +1302,7 @@ export function parseGenericExpression(
         const result = parseScriptFragmentWithOption(
             scriptLet,
             locationCalculator.getSubCalculatorShift(-14),
-            { ...parserOptions, project: undefined },
+            { ...parserOptions, project: undefined, projectService: undefined },
             {
                 preFixLocationProcess(preResult) {
                     const params = getParams(preResult)

--- a/test/parser-options-project.js
+++ b/test/parser-options-project.js
@@ -63,6 +63,11 @@ describe("use `project: undefined` when parsing template script-let", () => {
                     </MyComponent>
                 </div>
             </template>
+            <style scoped>
+            .a {
+                color: v-bind(color)
+            }
+            </style>
             `,
             {
                 project: true,

--- a/test/parser-options-project.js
+++ b/test/parser-options-project.js
@@ -1,0 +1,129 @@
+"use strict"
+
+const assert = require("assert")
+const { parseForESLint } = require("../src")
+const espree = require("espree")
+
+describe("use `project: undefined` when parsing template script-let", () => {
+    it("should be the project option is defined only once in Simple SFC.", () => {
+        let projectCount = 0
+        parseForESLint(
+            `<template>
+                <div v-bind:class="{}">
+                    <template v-for="item in items">
+                        {{ 'str' }}
+                        <button v-on:click="handler()"></button>
+                    </template>
+                    <MyComponent>
+                        <template v-slot="{a}">
+                            <div v-if="a">A</div>
+                        </template>
+                    </MyComponent>
+                </div>
+            </template>
+            <script>
+            export default {}
+            </script>
+            `,
+            {
+                project: true,
+                sourceType: "module",
+                ecmaVersion: 2018,
+                parser: {
+                    parseForESLint(code, options) {
+                        if (options.project) {
+                            projectCount++
+                        }
+
+                        return {
+                            ast: espree.parse(code, options),
+                        }
+                    },
+                },
+            },
+        )
+        assert.strictEqual(projectCount, 1)
+    })
+    it("should be the project option is defined only once in <script setup>.", () => {
+        let projectCount = 0
+        parseForESLint(
+            `<script setup>
+            let items = ["foo"]
+            </script>
+            <template>
+                <div v-bind:class="{}">
+                    <template v-for="item in items">
+                        {{ 'str' }}
+                        <button v-on:click="handler()"></button>
+                    </template>
+                    <MyComponent>
+                        <template v-slot="{a}">
+                            <div v-if="a">A</div>
+                        </template>
+                    </MyComponent>
+                </div>
+            </template>
+            `,
+            {
+                project: true,
+                sourceType: "module",
+                ecmaVersion: 2018,
+                parser: {
+                    parseForESLint(code, options) {
+                        if (options.project) {
+                            projectCount++
+                        }
+
+                        return {
+                            ast: espree.parse(code, options),
+                        }
+                    },
+                },
+            },
+        )
+        assert.strictEqual(projectCount, 1)
+    })
+
+    it("should be the project option is defined only once in <script setup> with <script>.", () => {
+        let projectCount = 0
+        parseForESLint(
+            `<script>
+            import { ref } from 'vue'
+            </script>
+            <script setup>
+            let items = ref(["foo"])
+            </script>
+            <template>
+                <div v-bind:class="{}">
+                    <template v-for="item in items">
+                        {{ 'str' }}
+                        <button v-on:click="handler()"></button>
+                    </template>
+                    <MyComponent>
+                        <template v-slot="{a}">
+                            <div v-if="a">A</div>
+                        </template>
+                    </MyComponent>
+                </div>
+            </template>
+            `,
+            {
+                project: true,
+                sourceType: "module",
+                ecmaVersion: 2018,
+                parser: {
+                    parseForESLint(code, options) {
+                        if (options.project) {
+                            projectCount++
+                        }
+
+                        return {
+                            ast: espree.parse(code, options),
+                        }
+                    },
+                },
+            },
+        )
+        assert.strictEqual(projectCount, 1)
+    })
+})


### PR DESCRIPTION
related to #104
close #65

This PR makes the parser option to use `project: undefined` when parsing script fragments in `<template>` blocks.
This should improve performance when used with the typescript-eslint parser.