### PR TITLE
feat(lang-ts): support lang="ts" in <style> and <custom> blocks

### DIFF
--- a/src/common/ast-utils.ts
+++ b/src/common/ast-utils.ts
@@ -14,7 +14,10 @@ import type {
  * @returns `true` if the node is a `<script>` element.
  */
 export function isScriptElement(node: VNode): node is VElement {
-    return node.type === "VElement" && node.name === "script"
+    return (
+        node.type === "VElement" &&
+        (node.name === "script" || getLang(node) === "ts")
+    )
 }
 
 /**
@@ -44,7 +47,11 @@ export function isTemplateElement(node: VNode): node is VElement {
  * @returns `true` if the node is a `<style>` element.
  */
 export function isStyleElement(node: VNode): node is VElement {
-    return node.type === "VElement" && node.name === "style"
+    return (
+        node.type === "VElement" &&
+        node.name === "style" &&
+        !(getLang(node) !== "ts")
+    )
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,12 +131,12 @@ function parseAsSFC(code: string, options: ParserOptions) {
             parser: scriptParser,
         })
     } else if (
-        scripts.length === 2 &&
+        scripts.length >= 2 &&
         (scriptSetup = scripts.find(isScriptSetupElement))
     ) {
         result = parseScriptSetupElements(
             scriptSetup,
-            scripts.find((e) => e !== scriptSetup)!,
+            scripts.filter((e) => e !== scriptSetup)!,
             code,
             new LinesAndColumns(tokenizer.lineTerminators),
             {

--- a/test/fixtures/lang-ts.vue
+++ b/test/fixtures/lang-ts.vue
@@ -1,0 +1,22 @@
+<template>
+  <div>
+  </div>
+</template>
+
+<script setup lang="ts">
+let test =       'hello-world'
+</script>
+
+<style lang="ts">
+      const testStyle = {
+  backgroundColor: 'red',
+     color: 'blue'
+}
+</style>
+
+<custom lang="ts">
+   const testi18n = {
+  en: 'hello World',
+  de: 'Hallo Welt'
+}
+</custom>

--- a/test/index.js
+++ b/test/index.js
@@ -539,6 +539,36 @@ describe("Basic tests", () => {
         })
     })
 
+    describe("About fixtures/lang-ts", () => {
+        it.only('Should parse lang="ts" blocks as script blocks', () => {
+            const ast = parse(
+                [
+                    "<template><div></div></template>",
+                    '<script lang="ts">const test = "test"</script>',
+                    '<style lang="ts">const testStyle = {}</style>',
+                    '<custom lang="ts">const testCustom = {}</custom>',
+                ].join("\n"),
+            )
+            const body = ast
+        })
+        it.only('Should treat lang="ts" blocks as script tags', async () => {
+            const cli = new ESLint({
+                cwd: FIXTURE_DIR,
+                overrideConfig: {
+                    env: { browser: true, node: true },
+                    parser: PARSER_PATH,
+                    parserOptions: {
+                        ...BABEL_PARSER_OPTIONS,
+                        sourceType: "module",
+                        ecmaVersion: 2017,
+                    },
+                },
+                useEslintrc: false,
+            })
+            const report = await cli.lintFiles(["lang-ts.vue"])
+        })
+    })
+
     describe("About unexpected-null-character errors", () => {
         it("should keep NULL in DATA state.", () => {
             const ast = parse("<template>\u0000</template>")


### PR DESCRIPTION
Resolvs #207 ;

This PR is still **work in progress*.

It currently:

- Adds a fixture for expected working setup
- Adds two tests for expected working outputs
- Begins implementation by:
	- Change filtering of nodes in `ast-utils` to cast `lang="ts"` blocks as <script> elements
	- Change `getScriptSetupModuleCodeBlocks`, `parseScriptSetupElements` and `parseAsSFC` implementation to support `scriptElements` instead of `scriptElement`
	
Any idea or suggestion for next steps is welcome :)