### PR TITLE
fix: ast difference between babel parser and typescript-eslint parser causes parse error

### DIFF
--- a/src/script/generic.ts
+++ b/src/script/generic.ts
@@ -124,7 +124,8 @@ function getConstraint(node: TSESTree.TSTypeParameter, rawParam: string) {
     if (!node.constraint) {
         return "unknown"
     }
-    let index = rawParam.indexOf(node.name.name) + node.name.name.length
+    const name = typeof node.name === "string" ? node.name : node.name.name
+    let index = rawParam.indexOf(name) + name.length
     let startIndex: number | null = null
     while (index < rawParam.length) {
         if (startIndex == null) {


### PR DESCRIPTION
babel 7 parses TSTypeParameter's `name` as a string, which causes errors when using babel parser with the generic attribute