### PR TITLE
fix: unintended version of espree loaded

### DIFF
--- a/src/common/espree.ts
+++ b/src/common/espree.ts
@@ -68,12 +68,16 @@ function getEspreeFromUser(): Espree {
  * If the loaded ESLint was not found, just returns `require("espree")`.
  */
 function getEspreeFromLinter(): Espree {
-    const require = getLinterRequire()
-    if (require) {
-        const espree = getEspreeFromRequireFunction(require)
-        if (espree) {
-            return espree
+    try {
+        const require = getLinterRequire()
+        if (require) {
+            const espree = getEspreeFromRequireFunction(require)
+            if (espree) {
+                return espree
+            }
         }
+    } catch {
+        // ignore
     }
     return dependencyEspree
 }

--- a/src/script-setup/parser-options.ts
+++ b/src/script-setup/parser-options.ts
@@ -1,5 +1,4 @@
-import { lte } from "semver"
-import { getEcmaVersionIfUseEspree, getEspreeFromUser } from "../common/espree"
+import { getEcmaVersionIfUseEspree } from "../common/espree"
 import type { ParserOptions } from "../common/parser-options"
 
 export const DEFAULT_ECMA_VERSION = 2017
@@ -10,21 +9,11 @@ export const DEFAULT_ECMA_VERSION = 2017
 export function getScriptSetupParserOptions(
     parserOptions: ParserOptions,
 ): ParserOptions {
-    const espreeEcmaVersion = getEcmaVersionIfUseEspree(
-        parserOptions,
-        getDefaultEcmaVersion,
-    )
+    const espreeEcmaVersion =
+        getEcmaVersionIfUseEspree(parserOptions) ?? parserOptions.ecmaVersion
 
     return {
         ...parserOptions,
         ecmaVersion: espreeEcmaVersion,
     }
-}
-
-function getDefaultEcmaVersion(def: number) {
-    if (lte("8.0.0", getEspreeFromUser().version)) {
-        // Script setup requires top level await support, so default the ecma version to 2022.
-        return getEspreeFromUser().latestEcmaVersion!
-    }
-    return Math.max(def, DEFAULT_ECMA_VERSION)
 }

--- a/src/script/index.ts
+++ b/src/script/index.ts
@@ -43,11 +43,7 @@ import {
     analyzeExternalReferences,
     analyzeVariablesAndExternalReferences,
 } from "./scope-analyzer"
-import {
-    getEcmaVersionIfUseEspree,
-    getEspreeFromUser,
-    getEspreeFromEcmaVersion,
-} from "../common/espree"
+import { getEcmaVersionIfUseEspree, getNewestEspree } from "../common/espree"
 import type { ParserOptions } from "../common/parser-options"
 import {
     fixErrorLocation,
@@ -571,7 +567,7 @@ function loadParser(parser: string) {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         return require(parser)
     }
-    return getEspreeFromUser()
+    return getNewestEspree()
 }
 
 /**
@@ -590,7 +586,7 @@ export function parseScript(
             ? loadParser(parserOptions.parser)
             : isParserObject(parserOptions.parser)
             ? parserOptions.parser
-            : getEspreeFromEcmaVersion(parserOptions.ecmaVersion)
+            : getNewestEspree()
 
     const result: any = isEnhancedParserObject(parser)
         ? parser.parseForESLint(code, parserOptions)

--- a/test/espree.js
+++ b/test/espree.js
@@ -8,94 +8,49 @@ const path = require("path")
 function parentMain() {
     const { spawn, execSync } = require("child_process")
 
-    describe("Loading espree from ESLint", () => {
-        it("should load espree from the ESLint location.", (done) => {
-            spawn(
-                process.execPath,
-                ["--require", "ts-node/register", __filename, "--child1"],
-                {
-                    stdio: "inherit",
-                },
-            )
-                .on("error", done)
-                .on("exit", (code) =>
-                    code
-                        ? done(new Error(`Exited with non-zero: ${code}`))
-                        : done(),
-                )
-        })
-        it("should load espree from the ESLint location.", (done) => {
-            spawn(
-                process.execPath,
-                ["--require", "ts-node/register", __filename, "--child1"],
-                {
-                    stdio: "inherit",
-                },
-            )
-                .on("error", done)
-                .on("exit", (code) =>
-                    code
-                        ? done(new Error(`Exited with non-zero: ${code}`))
-                        : done(),
-                )
-        })
-        it("should load espree from the user location.", (done) => {
-            const originalCwd = process.cwd()
-            try {
-                process.chdir(path.join(__dirname, "./fixtures/espree-v8"))
-                execSync("npm i", {
-                    stdio: "inherit",
-                })
-                spawn(
-                    process.execPath,
-                    ["--require", "ts-node/register", __filename, "--child2"],
-                    {
+    for (const loc of ["./fixtures/espree-v8", "./fixtures/eslint-v6"]) {
+        describe(`Loading espree for ${loc}`, () => {
+            it("should load espree from latest.", (done) => {
+                const originalCwd = process.cwd()
+                try {
+                    process.chdir(path.join(__dirname, loc))
+                    execSync("npm i", {
                         stdio: "inherit",
-                    },
-                )
-                    .on("error", done)
-                    .on("exit", (code) =>
-                        code
-                            ? done(new Error(`Exited with non-zero: ${code}`))
-                            : done(),
+                    })
+                    spawn(
+                        process.execPath,
+                        [
+                            "--require",
+                            "ts-node/register",
+                            __filename,
+                            "--child",
+                        ],
+                        {
+                            stdio: "inherit",
+                        },
                     )
-            } finally {
-                process.chdir(originalCwd)
-            }
+                        .on("error", done)
+                        .on("exit", (code) =>
+                            code
+                                ? done(
+                                      new Error(
+                                          `Exited with non-zero: ${code}`,
+                                      ),
+                                  )
+                                : done(),
+                        )
+                } finally {
+                    process.chdir(originalCwd)
+                }
+            })
         })
-    })
-}
-
-/**
- * Check this parser loads the `espree` from the location of the loaded ESLint.
- */
-function childMain1() {
-    const assert = require("assert")
-    const { Linter } = require("./fixtures/eslint")
-    const linter = new Linter()
-    linter.defineParser("vue-eslint-parser", require("../src"))
-
-    const beforeEsprees = Object.keys(require.cache).filter(isEspreePath)
-
-    linter.verify(
-        "<script>'hello'</script>",
-        { parser: "vue-eslint-parser" },
-        { filename: "a.vue" },
-    )
-
-    const afterEsprees = Object.keys(require.cache).filter(isEspreePath)
-
-    assert.strictEqual(
-        afterEsprees.length,
-        beforeEsprees.length,
-        "espree should be loaded from the expected place",
-    )
+    }
 }
 
 /**
  * Check this parser loads the `espree` from the location of the user dir.
  */
-function childMain2() {
+function childMain() {
     const assert = require("assert")
     const { Linter } = require("./fixtures/eslint")
     const linter = new Linter()
@@ -107,7 +62,7 @@ function childMain2() {
             parser: "vue-eslint-parser",
             parserOptions: {
                 parser: "espree",
-                ecmaVersion: 2022,
+                ecmaVersion: "latest",
                 sourceType: "module",
             },
         },
@@ -116,18 +71,12 @@ function childMain2() {
     assert.strictEqual(
         result.length,
         0,
-        "espree should be loaded from the fixtures/espree-v8",
+        "espree should be loaded from the " + process.cwd(),
     )
 }
 
-function isEspreePath(p) {
-    return p.includes(`${path.sep}node_modules${path.sep}espree${path.sep}`)
-}
-
-if (process.argv.includes("--child1")) {
-    childMain1()
-} else if (process.argv.includes("--child2")) {
-    childMain2()
+if (process.argv.includes("--child")) {
+    childMain()
 } else {
     parentMain()
 }

--- a/test/fixtures/ast/define-model06-with-ts/scope.json
+++ b/test/fixtures/ast/define-model06-with-ts/scope.json
@@ -878,6 +878,72 @@
             "references": []
         },
         {
+            "name": "FlatArray",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigIntToLocaleStringOptions",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigInt",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigIntConstructor",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigInt64Array",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigInt64ArrayConstructor",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigUint64Array",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigUint64ArrayConstructor",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "PromiseFulfilledResult",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "PromiseRejectedResult",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "PromiseSettledResult",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
             "name": "const",
             "identifiers": [],
             "defs": [],

--- a/test/fixtures/ast/define-model07-with-ts/scope.json
+++ b/test/fixtures/ast/define-model07-with-ts/scope.json
@@ -878,6 +878,72 @@
             "references": []
         },
         {
+            "name": "FlatArray",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigIntToLocaleStringOptions",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigInt",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigIntConstructor",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigInt64Array",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigInt64ArrayConstructor",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigUint64Array",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigUint64ArrayConstructor",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "PromiseFulfilledResult",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "PromiseRejectedResult",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "PromiseSettledResult",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
             "name": "const",
             "identifiers": [],
             "defs": [],

--- a/test/fixtures/ast/define-model08-with-ts-and-modifiers/scope.json
+++ b/test/fixtures/ast/define-model08-with-ts-and-modifiers/scope.json
@@ -878,6 +878,72 @@
             "references": []
         },
         {
+            "name": "FlatArray",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigIntToLocaleStringOptions",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigInt",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigIntConstructor",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigInt64Array",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigInt64ArrayConstructor",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigUint64Array",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigUint64ArrayConstructor",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "PromiseFulfilledResult",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "PromiseRejectedResult",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "PromiseSettledResult",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
             "name": "const",
             "identifiers": [],
             "defs": [],

--- a/test/fixtures/ast/define-slots01/scope.json
+++ b/test/fixtures/ast/define-slots01/scope.json
@@ -878,6 +878,72 @@
             "references": []
         },
         {
+            "name": "FlatArray",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigIntToLocaleStringOptions",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigInt",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigIntConstructor",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigInt64Array",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigInt64ArrayConstructor",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigUint64Array",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigUint64ArrayConstructor",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "PromiseFulfilledResult",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "PromiseRejectedResult",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "PromiseSettledResult",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
             "name": "const",
             "identifiers": [],
             "defs": [],

--- a/test/fixtures/ast/ts-script-setup-with-use-global-var/scope.json
+++ b/test/fixtures/ast/ts-script-setup-with-use-global-var/scope.json
@@ -878,6 +878,72 @@
             "references": []
         },
         {
+            "name": "FlatArray",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigIntToLocaleStringOptions",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigInt",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigIntConstructor",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigInt64Array",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigInt64ArrayConstructor",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigUint64Array",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigUint64ArrayConstructor",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "PromiseFulfilledResult",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "PromiseRejectedResult",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "PromiseSettledResult",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
             "name": "const",
             "identifiers": [],
             "defs": [],

--- a/test/fixtures/ast/vue3.3-generic-1/scope.json
+++ b/test/fixtures/ast/vue3.3-generic-1/scope.json
@@ -878,6 +878,72 @@
             "references": []
         },
         {
+            "name": "FlatArray",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigIntToLocaleStringOptions",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigInt",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigIntConstructor",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigInt64Array",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigInt64ArrayConstructor",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigUint64Array",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigUint64ArrayConstructor",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "PromiseFulfilledResult",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "PromiseRejectedResult",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "PromiseSettledResult",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
             "name": "const",
             "identifiers": [],
             "defs": [],

--- a/test/fixtures/ast/vue3.3-generic-2/scope.json
+++ b/test/fixtures/ast/vue3.3-generic-2/scope.json
@@ -878,6 +878,72 @@
             "references": []
         },
         {
+            "name": "FlatArray",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigIntToLocaleStringOptions",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigInt",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigIntConstructor",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigInt64Array",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigInt64ArrayConstructor",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigUint64Array",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigUint64ArrayConstructor",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "PromiseFulfilledResult",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "PromiseRejectedResult",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "PromiseSettledResult",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
             "name": "const",
             "identifiers": [],
             "defs": [],

--- a/test/fixtures/ast/vue3.3-generic-3/scope.json
+++ b/test/fixtures/ast/vue3.3-generic-3/scope.json
@@ -878,6 +878,72 @@
             "references": []
         },
         {
+            "name": "FlatArray",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigIntToLocaleStringOptions",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigInt",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigIntConstructor",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigInt64Array",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigInt64ArrayConstructor",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigUint64Array",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "BigUint64ArrayConstructor",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "PromiseFulfilledResult",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "PromiseRejectedResult",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
+            "name": "PromiseSettledResult",
+            "identifiers": [],
+            "defs": [],
+            "references": []
+        },
+        {
             "name": "const",
             "identifiers": [],
             "defs": [],

--- a/test/fixtures/eslint-v6/.npmrc
+++ b/test/fixtures/eslint-v6/.npmrc
@@ -1,0 +1,1 @@
+package-lock = false

--- a/test/fixtures/eslint-v6/package.json
+++ b/test/fixtures/eslint-v6/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "eslint-v6-test",
+  "private": true,
+  "version": "1.0.0",
+  "dependencies": {
+    "eslint": "^6.0.0"
+  }
+}


### PR DESCRIPTION
close #238

This PR fixes an issue where an older version of `espree` could be loaded unintentionally by the user.