### PR TITLE
Remove useless spread and fallbacks

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,7 @@ import typescriptEslint from "@typescript-eslint/eslint-plugin"
 import eslintComments from "eslint-plugin-eslint-comments"
 import node from "eslint-plugin-n"
 import nodeDeps from "eslint-plugin-node-dependencies"
+import unicorn from "eslint-plugin-unicorn"
 import tsParser from "@typescript-eslint/parser"
 import jsonParser from "jsonc-eslint-parser"
 import path from "node:path"
@@ -114,6 +115,7 @@ export default [
             "@typescript-eslint": typescriptEslint,
             "eslint-comments": eslintComments,
             node,
+            unicorn,
         },
 
         languageOptions: {
@@ -779,6 +781,8 @@ export default [
                     ],
                 },
             ],
+
+            "unicorn/no-useless-fallback-in-spread": ["error"],
         },
     },
     {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -783,6 +783,7 @@ export default [
             ],
 
             "unicorn/no-useless-fallback-in-spread": ["error"],
+            "unicorn/no-useless-spread": ["error"],
         },
     },
     {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-n": "^17.15.1",
     "eslint-plugin-node-dependencies": "^0.12.0",
     "eslint-plugin-prettier": "^5.2.3",
+    "eslint-plugin-unicorn": "^57.0.0",
     "fs-extra": "^10.0.0",
     "jsonc-eslint-parser": "^2.0.3",
     "mocha": "^9.1.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ export function parseForESLint(
         loc: true,
         range: true,
         tokens: true,
-        ...(parserOptions ?? {}),
+        ...parserOptions,
     }
 
     let result: AST.ESLintExtendedProgram
@@ -69,7 +69,7 @@ export function parseForESLint(
     }
 
     result.services = {
-        ...(result.services || {}),
+        ...result.services,
         ...services.define(code, result.ast, document, locationCalculator, {
             parserOptions: options,
         }),

--- a/src/script/generic.ts
+++ b/src/script/generic.ts
@@ -95,7 +95,7 @@ export function extractGeneric(element: VElement): GenericProcessInfo | null {
         typeDefScope: Scope,
         isRemoveTarget: (nodeOrToken: HasLocation) => boolean,
     ) {
-        for (const variable of [...typeDefScope.variables]) {
+        for (const variable of typeDefScope.variables) {
             let def = variable.defs.find((d) =>
                 isRemoveTarget(d.name as HasLocation),
             )
@@ -106,13 +106,13 @@ export function extractGeneric(element: VElement): GenericProcessInfo | null {
                 )
             }
         }
-        for (const reference of [...typeDefScope.references]) {
+        for (const reference of typeDefScope.references) {
             if (isRemoveTarget(reference.identifier as HasLocation)) {
                 removeReference(reference, typeDefScope)
             }
         }
 
-        for (const scope of [...scopeManager.scopes]) {
+        for (const scope of scopeManager.scopes) {
             if (isRemoveTarget(scope.block as HasLocation)) {
                 removeScope(scopeManager, scope)
             }

--- a/src/sfc/custom-block/index.ts
+++ b/src/sfc/custom-block/index.ts
@@ -263,7 +263,7 @@ export function createCustomBlockSharedContext({
                         { ...parserOptions, ...options },
                     )
                 },
-                ...(parsedResult.services ?? {}),
+                ...parsedResult.services,
                 ...(parsedResult.error
                     ? { parseError: parsedResult.error }
                     : {}),


### PR DESCRIPTION
Was reading code, and found some cases that unicorn can prevent.

If you don't want keep the rules, I can remove them.

BTW: The eslint config seems not working right, when I run `eslint --fix`, there are more change (some are wrong) applied, maybe because of version of dependencies.