### PR TITLE
fix: adopt child scopes of removed script setup block scope

### DIFF
--- a/src/script-setup/index.ts
+++ b/src/script-setup/index.ts
@@ -947,7 +947,7 @@ function remapAST(
         if (upper) {
             const index = upper.childScopes.indexOf(blockScope)
             if (index >= 0) {
-                upper.childScopes.splice(index, 1)
+                upper.childScopes.splice(index, 1, ...blockScope.childScopes)
             }
         }
         const index = scopeManager.scopes.indexOf(blockScope)


### PR DESCRIPTION
Currently the child scopes of the created block scope for `<script setup>` are not adopted by the module scope.
In other words the scopes exist (see #228) but they are not reachable by using `moduleScope.childScopes` (which is always empty).
The fix simply moves the child scopes of the created block scope into the child scopes of the module scope.

I marked this PR as a draft as 8 fixture tests (e.g. `define-model06-with-ts`) fail without changing the code, so I did not additional fixtures.
No additional fixture tests fail when applying the fix, so this behavior looks like an oversight.
I will add test cases if the new behavior is accepted.
Fixes #228.