### PR TITLE
chore(ci): set explicit least-privilege workflow permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,6 +7,9 @@ on:
   schedule:
   - cron: 0 0 * * 0
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
## Summary
- add an explicit `permissions` block to CI workflow
- limit workflow `GITHUB_TOKEN` to `contents: read`
- keep lint/test matrix and schedule behavior unchanged

## Why
This is a low-risk hardening change to enforce least privilege and make workflow token scope explicit.