### PR TITLE
fix: parse dotted v-slot names as slot names

### DIFF
--- a/src/template/index.ts
+++ b/src/template/index.ts
@@ -162,6 +162,7 @@ function parseDirectiveKeyStatically(
         directiveKey.argument = modifiers.shift() ?? null
     }
     directiveKey.modifiers = modifiers.filter(isNotEmptyModifier)
+    normalizeSlotDirectiveKeyArgument(directiveKey, text, rawText, offset)
 
     if (directiveKey.name.name === "v-") {
         insertError(
@@ -190,6 +191,36 @@ function parseDirectiveKeyStatically(
     }
 
     return directiveKey
+}
+
+function normalizeSlotDirectiveKeyArgument(
+    directiveKey: VDirectiveKey,
+    text: string,
+    rawText: string,
+    offset: number,
+) {
+    if (!isSlotDirectiveKeyName(directiveKey.name.name)) {
+        return
+    }
+
+    const lastModifier = directiveKey.modifiers.at(-1)
+    if (directiveKey.argument != null && lastModifier != null) {
+        const argumentStart = directiveKey.argument.range[0] - offset
+        const argumentEnd = lastModifier.range[1] - offset
+        directiveKey.argument.range[1] = lastModifier.range[1]
+        directiveKey.argument.loc.end = lastModifier.loc.end
+        directiveKey.argument.name = text.slice(argumentStart, argumentEnd)
+        directiveKey.argument.rawName = rawText.slice(
+            argumentStart,
+            argumentEnd,
+        )
+    }
+
+    directiveKey.modifiers = []
+}
+
+function isSlotDirectiveKeyName(name: string) {
+    return name === "slot" || name === "v-slot"
 }
 
 /**

--- a/test/directive-key.test.ts
+++ b/test/directive-key.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, assert } from "vitest"
+import { parseForESLint } from "../src"
+import type { VAttribute, VDirective } from "../src/ast"
+
+function getFirstDirective(code: string): VDirective {
+    const result = parseForESLint(code, {
+        filePath: "test.vue",
+        ecmaVersion: "latest",
+        sourceType: "module",
+    })
+    assert.deepStrictEqual(result.ast.templateBody?.errors, [])
+
+    const queue = [...(result.ast.templateBody?.children ?? [])]
+    while (queue.length > 0) {
+        const node = queue.shift()!
+        if (node.type === "VElement") {
+            const directive = node.startTag.attributes.find(
+                (attr: VAttribute): attr is VDirective => attr.directive,
+            )
+            if (directive) {
+                return directive
+            }
+            queue.push(...node.children)
+        }
+    }
+
+    throw new Error("Expected to find a directive.")
+}
+
+describe("directive key", () => {
+    it("parses dots in static v-slot arguments as part of the slot name", () => {
+        const directive = getFirstDirective(
+            '<template><Foobar><template v-slot:head(foo.bar).baz="props"></template></Foobar></template>',
+        )
+
+        assert.strictEqual(directive.key.name.name, "slot")
+        assert.strictEqual(directive.key.argument?.type, "VIdentifier")
+        assert.strictEqual(directive.key.argument.rawName, "head(foo.bar).baz")
+        assert.deepStrictEqual(directive.key.modifiers, [])
+    })
+
+    it("parses dots in v-slot shorthand arguments as part of the slot name", () => {
+        const directive = getFirstDirective(
+            '<template><Foobar><template #head.foo="props"></template></Foobar></template>',
+        )
+
+        assert.strictEqual(directive.key.name.name, "slot")
+        assert.strictEqual(directive.key.argument?.type, "VIdentifier")
+        assert.strictEqual(directive.key.argument.rawName, "head.foo")
+        assert.deepStrictEqual(directive.key.modifiers, [])
+    })
+
+    it("preserves modifiers on non-slot directive keys", () => {
+        const vOn = getFirstDirective(
+            '<template><button v-on:click.stop="handler"></button></template>',
+        )
+        assert.strictEqual(vOn.key.argument?.type, "VIdentifier")
+        assert.strictEqual(vOn.key.argument.rawName, "click")
+        assert.deepStrictEqual(
+            vOn.key.modifiers.map((modifier) => modifier.rawName),
+            ["stop"],
+        )
+
+        const vBind = getFirstDirective(
+            '<template><button v-bind:foo.bar="value"></button></template>',
+        )
+        assert.strictEqual(vBind.key.argument?.type, "VIdentifier")
+        assert.strictEqual(vBind.key.argument.rawName, "foo")
+        assert.deepStrictEqual(
+            vBind.key.modifiers.map((modifier) => modifier.rawName),
+            ["bar"],
+        )
+    })
+})


### PR DESCRIPTION
﻿## Summary

- align `v-slot` directive key parsing with Vue compiler behavior by folding dot-separated segments back into static slot arguments
- keep non-slot directive modifiers such as `v-on:click.stop` and `v-bind:foo.bar` unchanged
- add regression coverage for long-form and shorthand `v-slot` names containing dots

## Root Cause

`parseDirectiveKeyStatically` split directive keys on every `.` and treated the remaining segments as modifiers for all directives. Vue compiler treats dot segments on `v-slot` as part of the static slot name, so a slot like `v-slot:head(foo.bar)` should expose `head(foo.bar)` as the argument and no modifiers.

Fixes #276.

## Validation

- `npm run lint`
- `npx vitest run test/directive-key.test.ts`
- `npx vitest run test/ast.test.ts test/index.test.ts test/directive-key.test.ts`
- `npm test -- --run`
- `npm run build` (passes; current dependency declaration warnings are still emitted)
