### PR TITLE
fix: keep `<script setup>` child scopes in the scope tree

### DIFF
--- a/src/script-setup/index.ts
+++ b/src/script-setup/index.ts
@@ -942,12 +942,20 @@ function remapAST(
                 moduleScope.set.set(variable.name, variable)
             }
         }
+        // Restore child scopes.
+        // Without this, scopes of functions declared in `<script setup>` stay attached to the removed block scope.
+        // They remain in `ScopeManager#scopes`, but rules that traverse `Scope#childScopes` from the `Program` scope
+        // (`no-use-before-define`, `no-shadow`, ...) never reach them and silently report nothing.
+        for (const childScope of blockScope.childScopes) {
+            childScope.upper = moduleScope
+        }
         // Remove scope
         const upper = blockScope.upper
         if (upper) {
             const index = upper.childScopes.indexOf(blockScope)
             if (index >= 0) {
-                upper.childScopes.splice(index, 1)
+                // Put the child scopes where the block scope was, so they stay in source order
+                upper.childScopes.splice(index, 1, ...blockScope.childScopes)
             }
         }
         const index = scopeManager.scopes.indexOf(blockScope)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -989,6 +989,109 @@ export default {}
             // Verify comments are sorted by range
             assert.ok(comments[0].range[0] < comments[1].range[0])
         })
+
+        it("should keep scopes of `<script setup>` functions in the scope tree", () => {
+            const code = `<script lang="ts">
+export const fromFirstScript = () => {
+    return 1
+}
+</script>
+
+<script lang="ts" setup>
+const outer = () => {
+    return inner()
+}
+
+const inner = () => {
+    return 2
+}
+</script>`
+
+            const result = parseForESLint(code, {
+                parser: "@typescript-eslint/parser",
+                sourceType: "module",
+            })
+            const scopeManager = result.scopeManager!
+
+            type ScopeOfManager = (typeof scopeManager.scopes)[number]
+
+            const reachableScopes = new Set<ScopeOfManager>()
+            const collectScopes = (scope: ScopeOfManager) => {
+                reachableScopes.add(scope)
+                scope.childScopes.forEach(collectScopes)
+            }
+            collectScopes(scopeManager.globalScope)
+
+            // Scopes of `outer` and `inner` must be reachable by walking `childScopes` from the global scope,
+            // otherwise rules that traverse the tree (`no-use-before-define`, `no-shadow`, ...) skip them
+            assert.deepStrictEqual(
+                scopeManager.scopes.filter(
+                    (scope) => !reachableScopes.has(scope),
+                ),
+                [],
+            )
+
+            // Every scope must be linked to a scope that is still part of the scope manager,
+            // so that rules walking up through `Scope#upper` never land on the removed block scope
+            assert.deepStrictEqual(
+                scopeManager.scopes.filter(
+                    (scope) =>
+                        scope.upper &&
+                        !scopeManager.scopes.includes(scope.upper),
+                ),
+                [],
+            )
+
+            // The child scopes take the place of the removed block scope, so they stay in source order
+            const moduleScope = scopeManager.globalScope.childScopes.find(
+                (scope) => scope.type === "module",
+            )!
+            const childScopeStarts = moduleScope.childScopes.map(
+                (scope) => scope.block.range![0],
+            )
+            assert.deepStrictEqual(
+                childScopeStarts,
+                [...childScopeStarts].sort((a, b) => a - b),
+            )
+        })
+
+        it("should notify no-use-before-define error in `<script setup>` with a `<script>` block", () => {
+            const code = `<script lang="ts">
+export interface ExportedFromFirstScript {
+    name: string
+}
+</script>
+
+<script lang="ts" setup>
+const outer = () => {
+    return inner()
+}
+
+const inner = () => {
+    return 1
+}
+</script>`
+            const config: eslint.Linter.Config = {
+                languageOptions: {
+                    parser,
+                    parserOptions: {
+                        parser: "@typescript-eslint/parser",
+                        sourceType: "module",
+                    },
+                },
+                rules: {
+                    "no-use-before-define": "error",
+                },
+            }
+            const linter = new Linter()
+            const messages = linter.verify(code, config)
+
+            assert.strictEqual(messages.length, 1)
+            assert.strictEqual(
+                messages[0].message,
+                "'inner' was used before it was defined.",
+            )
+        })
     })
 })
 


### PR DESCRIPTION
When an SFC has both `<script>` and `<script setup>`, scopes of functions declared in `<script setup>` are detached from the scope tree. Rules that traverse it from the `Program` scope — `no-use-before-define`, `no-shadow` and others — never reach those scopes and silently report nothing. There is no parsing error and no warning: the checks are just disabled.

Minimal reproduction: https://github.com/Holiden/vue-eslint-parser-repro

Two SFCs with an identical `<script setup>` body, the second one has an extra `<script lang="ts">` block that exports an interface. `npm run lint` reports only the single-block file:

```
src/OneScript.vue
  10:9   error  'shadowed' is already declared in the upper scope  no-shadow
  13:10  error  'inner' was used before it was defined             no-use-before-define

✖ 2 problems (2 errors, 0 warnings)
```

Only reproducible when a parser supplies its own scope manager, such as `@typescript-eslint/parser`. With the default parser the scope manager is built after the AST is remapped, so the tree stays consistent.

## Cause

`remapScope()` unwraps the virtual block statement the `<script setup>` statements are parsed inside: it moves the block scope's `references` and `variables` into the module scope and then removes the block scope from `upper.childScopes` and from `ScopeManager#scopes`. Its child scopes were left behind — they stay in `ScopeManager#scopes`, but their `upper` points at the removed scope and nothing points back at them.

## Fix

Put the child scopes where the block scope was, so they stay in source order, and point their `upper` at the module scope so that walking up never lands on a scope that is no longer in the scope manager.

## Relation to #228 and #291

Fixes #228, reported by @DMartens back in 2024.

This is an alternative to #291 by the same author, which fixes the same bug — I ran into it independently before finding either. The two differ in what they restore:

| | Child scopes reachable | Position in `childScopes` | `upper` of child scopes |
| --- | --- | --- | --- |
| current release | no | — | removed block scope |
| #291 | yes | kept (`splice` in place) | removed block scope |
| this PR | yes | kept (`splice` in place) | module scope |

`splice` in place comes from #291 — it keeps the child scopes in source order, which matters when the first `<script>` block declares functions of its own. On top of that, this PR repoints `upper` at the module scope: otherwise every child scope keeps referencing a scope that is no longer in `ScopeManager#scopes`, and rules that walk up through `Scope#upper` pass through a phantom scope.

One more note for maintainers: #291 was kept as a draft because 8 fixture tests (e.g. `define-model06-with-ts`) were failing on `master` regardless of the change. On the current `master` (cd8026f, 10.4.1) they pass — I ran the suite there: 1696 passed, 0 failed. So that blocker is gone, and this PR adds the test cases @DMartens offered to write.

## Tests

Two cases added to `test/index.test.ts` (`Multiple <script>` block):

- every scope in `ScopeManager#scopes` is reachable by walking `childScopes` from the global scope, no scope points at an `upper` outside the scope manager, and the module scope's child scopes stay in source order;
- `no-use-before-define` reports the expected error in an SFC with both `<script>` and `<script setup>`.

`npm test` — 1698 passed, 4 skipped. `npm run lint` and `npm run build` — clean.
